### PR TITLE
NameError: global name 'sys' is not defined

### DIFF
--- a/django_jinja/base.py
+++ b/django_jinja/base.py
@@ -15,6 +15,7 @@ from django.template.loaders import app_directories
 from django.utils.importlib import import_module
 
 import os
+import sys
 import copy
 
 JINJA2_ENVIRONMENT_OPTIONS = getattr(settings, 'JINJA2_ENVIRONMENT_OPTIONS', {})


### PR DESCRIPTION
0.8 is broken for me, this likely takes care of it.
