### PR TITLE
Prevent certain apps from using Jinja2 Templates

### DIFF
--- a/django_jinja/loaders.py
+++ b/django_jinja/loaders.py
@@ -8,7 +8,7 @@ from django.template.loaders import filesystem
 from django_jinja.base import env
 import jinja2
 
-DEFAULT_JINJA2_TEMPLATE_EXTENSION = getattr(settings,
+DEFAULT_JINJA2_TEMPLATE_EXTENSION = getattr(settings, 'DEFAULT_JINJA2_TEMPLATE_EXTENSION')
 
 
 class LoaderMixin(object):


### PR DESCRIPTION
Sometimes you want certain apps not to use Jinja2 templates but the standard Django templates. Think for example of the Django admin templates.

This is easily done by slightly altering the LoaderMixin.load_template().

Now you can add the KEEP_DJANGO_TEMPLATES variable to your settings.

KEEP_DJANGO_TEMPLATES = ['admin', ]
