### PR TITLE
Update base.py

### DIFF
--- a/django_jinja/base.py
+++ b/django_jinja/base.py
@@ -190,6 +190,9 @@ class Environment(Environment):
                 pass
 
         for app_path, mod_path in mod_list:
+            if not os.path.isdir(mod_path):
+                continue
+                
             for filename in filter(lambda x: x.endswith(".py"), os.listdir(mod_path)):
                 if filename == '__init__.py':
                     continue


### PR DESCRIPTION
avoid an OS error when scanning mod_path's that are not physical directories (such as eggs)
