### PR TITLE
Templates from 4xx/500 had hardcoded extension ".jinja"

### DIFF
--- a/django_jinja/views.py
+++ b/django_jinja/views.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from django.conf import settings
 from django.views.generic import View
 from django.template import loader, RequestContext
 from django import http
@@ -22,15 +23,15 @@ class GenericView(View):
 
 
 class PageNotFound(GenericView):
-    tmpl_name = "404.jinja"
+    tmpl_name = "404" + getattr(settings, 'DEFAULT_JINJA2_TEMPLATE_EXTENSION', '.jinja')
     response_cls = http.HttpResponseNotFound
 
 
 class PermissionDenied(GenericView):
-    tmpl_name = "403.jinja"
+    tmpl_name = "403" + getattr(settings, 'DEFAULT_JINJA2_TEMPLATE_EXTENSION', '.jinja')
     response_cls = http.HttpResponseForbidden
 
 
 class ServerError(GenericView):
-    tmpl_name = "500.jinja"
+    tmpl_name = "500" + getattr(settings, 'DEFAULT_JINJA2_TEMPLATE_EXTENSION', '.jinja')
     response_cls = http.HttpResponseServerError


### PR DESCRIPTION
DEFAULT_JINJA2_TEMPLATE_EXTENSION allow to change the default extension from templates,
the errors views should follow this behavior.
