### PR TITLE
Suppress exception NoReverseMatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ versiontools-*.egg
 *.egg-info
 .project
 .pydevproject
+.idea
 .settings

--- a/django_jinja/builtins/global_context.py
+++ b/django_jinja/builtins/global_context.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
-
-from django.core.urlresolvers import reverse as django_reverse
+import logging
+from django.core.urlresolvers import reverse as django_reverse, NoReverseMatch
 from django.contrib.staticfiles.storage import staticfiles_storage
+
 
 def url(name, *args, **kwargs):
     """
@@ -15,7 +16,11 @@ def url(name, *args, **kwargs):
         {% url 'web:timeline' userid=2 %}
 
     """
-    return django_reverse(name, args=args, kwargs=kwargs)
+    try:
+        return django_reverse(name, args=args, kwargs=kwargs)
+    except NoReverseMatch as exc:
+        logging.error('Error: %s', exc.message)
+        return ''
 
 
 def static(path):

--- a/example_project/example_project/urls.py
+++ b/example_project/example_project/urls.py
@@ -1,4 +1,5 @@
 from django.conf.urls import patterns, include, url
+from django.views.generic.base import TemplateView
 
 # Uncomment the next two lines to enable the admin:
 # from django.contrib import admin
@@ -18,4 +19,5 @@ urlpatterns = patterns('',
     # url(r'^admin/', include(admin.site.urls)),
     url(r'^test1/$', Test1.as_view(), name='test-1'),
     url(r'^test2/$', Test2.as_view(), name='test-2'),
+    url(r'^test3/$', TemplateView.as_view(template_name='test3.jinja'), name='test-3')
 )

--- a/example_project/example_project/web/templates/test3.jinja
+++ b/example_project/example_project/web/templates/test3.jinja
@@ -1,0 +1,13 @@
+{% extends "base.jinja" %}
+
+{% block body %}
+    <div class="header">Test function url()</div>
+    <ul>
+        <li>
+            <a href="{{ url('test-1') }}">Exist URL: {{ url('test-1') }}</a>
+        </li>
+        <li>
+            <a href="{{ url('test-miss') }}">Miss URL: {{ url('test-miss') }}</a>
+        </li>
+    </ul>
+{% endblock %}

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ if sys.version_info < (2, 7):
 
 setup(
     name = "django-jinja",
-    version = "0.22",
+    version = "0.22.1",
     description = "Jinja2 templating language integrated in Django.",
     long_description = "",
     keywords = "django, jinja2",


### PR DESCRIPTION
Suppress exception NoReverseMatch for django reverse url and notify via logging system.

Usage example:

```
    {% set url_path=url('web:timeline', userid=2) %}
    {# url_path == ''  for miss url path #}
```

This is a equivalent to django:

```
    {% url 'web:timeline' userid=2 as url_path %}
```
