### PR TITLE
builtins/url: Change parameter name so it does not conflict with an url ...

### DIFF
--- a/django_jinja/builtins/global_context.py
+++ b/django_jinja/builtins/global_context.py
@@ -10,7 +10,7 @@ JINJA2_MUTE_URLRESOLVE_EXCEPTIONS = getattr(settings, "JINJA2_MUTE_URLRESOLVE_EX
 logger = logging.getLogger(__name__)
 
 
-def url(name, *args, **kwargs):
+def url(view_name, *args, **kwargs):
     """
     Shortcut filter for reverse url on templates. Is a alternative to
     django {% url %} tag, but more simple.
@@ -23,7 +23,7 @@ def url(name, *args, **kwargs):
 
     """
     try:
-        return django_reverse(name, args=args, kwargs=kwargs)
+        return django_reverse(view_name, args=args, kwargs=kwargs)
     except NoReverseMatch as exc:
         logger.error('Error: %s', exc)
         if not JINJA2_MUTE_URLRESOLVE_EXCEPTIONS:


### PR DESCRIPTION
...parameter called "name".

This reflects the same name used in https://github.com/coffin/coffin/blob/master/coffin/template/defaultfilters.py, but it's probably as bad as a solution, because now you cannot use url() with a "view_name" url parameter. Maybe a better way to implement it would be to pop the first *args element (that'd raise if no arg is provided) and use it as the view name.
