### PR TITLE
Fix crash during loading

### DIFF
--- a/django_jinja/base.py
+++ b/django_jinja/base.py
@@ -276,7 +276,8 @@ class Environment(Environment):
         for app_path in all_modules:
             try:
                 mod = import_module(app_path + ".templatetags")
-                mod_list.append((app_path, os.path.dirname(mod.__file__)))
+                if mod is not None:
+                    mod_list.append((app_path, os.path.dirname(mod.__file__)))
             except ImportError:
                 pass
 


### PR DESCRIPTION
If the `templatetags` folder exists and is empty, `import_module` will succeed, but `mod` will we be None, then bad things will happen in `mod.__file__`.

This situation can occur in a build server in a git working copy, because git doesn't know about directories, so if a templatetag is added and then removed, the directory will stay empty forever.

I think that in this situation, we should just skip the module, because obviously it contains no template tags. Thoughts ?
