### PR TITLE
Django 1.8 bytecode cache

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,8 @@ Simple and nonobstructive jinja2 integration with Django.
 **Now with support for django 1.8**
 
 
-.. image:: https://img.shields.io/travis/niwibe/django-jinja.svg?style=flat
-    :target: https://travis-ci.org/niwibe/django-jinja
+.. image:: https://img.shields.io/travis/niwinz/django-jinja.svg?style=flat
+    :target: https://travis-ci.org/niwinz/django-jinja
 
 .. image:: https://img.shields.io/pypi/v/django-jinja.svg?style=flat
     :target: https://pypi.python.org/pypi/django-jinja
@@ -16,7 +16,7 @@ Simple and nonobstructive jinja2 integration with Django.
     :target: https://pypi.python.org/pypi/django-jinja
 
 
-**Documentation:** http://niwibe.github.io/django-jinja/
+**Documentation:** http://niwinz.github.io/django-jinja/
 
 
 How to install?

--- a/django_jinja/backend.py
+++ b/django_jinja/backend.py
@@ -149,6 +149,7 @@ class Jinja2(BaseEngine):
                                   constants=extra_constants)
 
         base._initialize_thirdparty(self.env)
+        base._initialize_bytecode_cache(self.env)
 
     def _initialize_builtins(self, filters=None, tests=None, globals=None, constants=None):
         def insert(data, name, value):

--- a/django_jinja/cache.py
+++ b/django_jinja/cache.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-
-from django.core.cache import get_cache
+import django
 from django.utils.functional import cached_property
 from jinja2 import BytecodeCache as _BytecodeCache
 
@@ -15,7 +14,12 @@ class BytecodeCache(_BytecodeCache):
 
     @cached_property
     def backend(self):
-        return get_cache(self._cache_name)
+        if django.VERSION[:2] < (1, 8):
+            from django.core.cache import get_cache
+            return get_cache(self._cache_name)
+        else:
+            from django.core.cache import caches
+            return caches[self._cache_name]
 
     def load_bytecode(self, bucket):
         key = 'jinja2_%s' % str(bucket.key)

--- a/django_jinja/library.py
+++ b/django_jinja/library.py
@@ -60,7 +60,7 @@ def _register_function(attr, name=None, fn=None):
 
 def extension(extension):
     global _local_env
-    _local_env["extensions"].add(extensions)
+    _local_env["extensions"].add(extension)
 
 
 def global_function(*args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     keywords = "django, jinja2",
     author = "Andrey Antukh",
     author_email = "niwi@niwi.be",
-    url = "https://github.com/niwibe/django-jinja",
+    url = "https://github.com/niwinz/django-jinja",
     license = "BSD",
     packages = [
         "django_jinja",


### PR DESCRIPTION
This PR adds initialization of bytecode cache for django 1.8 by calling initialize method from backend (maybe I misunderstood architecture, but I couldn't force it to run without such changes). Also I fix a little typo and add django 1.8+ compatibility for cache backend (get_cache is deprecated since version 1.8).