### PR TITLE
Extension decorator should return the extension

### DIFF
--- a/django_jinja/library.py
+++ b/django_jinja/library.py
@@ -61,6 +61,7 @@ def _register_function(attr, name=None, fn=None):
 def extension(extension):
     global _local_env
     _local_env["extensions"].add(extension)
+    return extension
 
 
 def global_function(*args, **kwargs):


### PR DESCRIPTION
Using the `@library.extension` decorator (in master, it doesn't work in 1.4.1 as per #153) results in the class being set to `None` in the module where it is defined, which isn't a massive deal since it does get registered – unless you happen to reference the class in the file (or anywhere else) e.g. in a `super` call.

I expect the decorator needs to just return the class unmodified since all it's doing is appending it to the array of extensions.

Resolves #154.