### PR TITLE
Fix exception when throwing exception on Django 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,7 @@ env:
   - DJANGO="django==1.9"
 
 install:
-  - pip install $DJANGO
-  - pip install jinja2 django-pipeline
-  - pip install pytz
+  - pip install $DJANGO jinja2 "django-pipeline<1.6" pytz
 
 matrix:
   exclude:

--- a/django_jinja/backend.py
+++ b/django_jinja/backend.py
@@ -276,9 +276,15 @@ class Jinja2(BaseEngine):
         try:
             return Template(self.env.get_template(template_name), self)
         except jinja2.TemplateNotFound as exc:
+
+            if utils.DJANGO_18:
+                exc = TemplateDoesNotExist(exc.name)
+            else:
+                exc = TemplateDoesNotExist(exc.name, backend=self)
+
             six.reraise(
                 TemplateDoesNotExist,
-                TemplateDoesNotExist(exc.name, backend=self),
+                exc,
                 sys.exc_info()[2],
             )
         except jinja2.TemplateSyntaxError as exc:

--- a/django_jinja/cache.py
+++ b/django_jinja/cache.py
@@ -14,12 +14,8 @@ class BytecodeCache(_BytecodeCache):
 
     @cached_property
     def backend(self):
-        if django.VERSION[:2] < (1, 8):
-            from django.core.cache import get_cache
-            return get_cache(self._cache_name)
-        else:
-            from django.core.cache import caches
-            return caches[self._cache_name]
+        from django.core.cache import caches
+        return caches[self._cache_name]
 
     def load_bytecode(self, bucket):
         key = 'jinja2_%s' % str(bucket.key)

--- a/django_jinja/utils.py
+++ b/django_jinja/utils.py
@@ -3,8 +3,12 @@
 import functools
 from importlib import import_module
 
+import django
 from django.utils.safestring import mark_safe
 from django.core.exceptions import ImproperlyConfigured
+
+
+DJANGO_18 = (django.VERSION[:2] == (1, 8))
 
 
 def load_class(path):


### PR DESCRIPTION
As the commit message says, `TemplateDoesNotExist` only learned about keyword parameters in Django 1.9.

See https://github.com/django/django/pull/4556 too :)