### PR TITLE
UnicodeDecodeError with cache tag

### DIFF
--- a/django_jinja/builtins/extensions.py
+++ b/django_jinja/builtins/extensions.py
@@ -133,6 +133,8 @@ class CacheExtension(Extension):
         if value is None:
             value = caller()
             cache.set(cache_key, force_text(value), expire_time)
+        else:
+            value = force_text(value)
 
         return value
 


### PR DESCRIPTION
Template fragment cache ({% cache %}) returns 'str' object instead of 'unicode' with django.core.cache.backends.memcached.MemcachedCache backend. This yields UnicodeDecodeError if fragment contains unicode data.

If i change ``return value`` to ``return force_text(value)`` in CacheExtension everything works OK.