### PR TITLE
Allow to provide a custom loader class as string, backward compatible

### DIFF
--- a/django_jinja/backend.py
+++ b/django_jinja/backend.py
@@ -172,7 +172,14 @@ class Jinja2(BaseEngine):
 
         environment_cls = import_string(environment_clspath)
 
-        options.setdefault("loader", jinja2.FileSystemLoader(self.template_dirs))
+        if isinstance(options.get("loader"), six.string_types):
+            # Allow to specify a loader as string
+            loader_cls = import_string(options.pop("loader"))
+        else:
+            # Backward compatible default
+            loader_cls = jinja2.FileSystemLoader
+
+        options.setdefault("loader", loader_cls(self.template_dirs))
         options.setdefault("extensions", builtins.DEFAULT_EXTENSIONS)
         options.setdefault("auto_reload", settings.DEBUG)
         options.setdefault("autoescape", True)


### PR DESCRIPTION
Apparently, some work has been done in older verions of django_jinja about this (see #47 and #48) but this feature is not available anymore in 2.x (see https://github.com/niwinz/django-jinja/blob/master/django_jinja/backend.py#L175). In fact, it is possible to specify a loader option, but only as a Loader instance and not using a string notation. This is a problem because self.template_dirs won't be available outside of the constructor.

I did a small patch about this that should be backward compatible, let me know what you think (whether or not this kind of PR is ok for django-jinja, if I need to add more stuff around, etc.).
