### PR TITLE
Fix `template_rendered` signal call arguments

### DIFF
--- a/django_jinja/backend.py
+++ b/django_jinja/backend.py
@@ -98,7 +98,7 @@ class Template(object):
 
                 context = CompatibilityContext(context)
 
-            signals.template_rendered.send(sender=self, template=self,
+            signals.template_rendered.send(sender=self, template=self.template,
                                            context=context)
 
 

--- a/testing/testapp/tests.py
+++ b/testing/testapp/tests.py
@@ -275,7 +275,7 @@ class RenderTemplatesTests(TestCase):
     def test_context_manipulation(self):
         response = self.client.get(reverse("test-1"))
         self.assertEqual(response.context["name"], "Jinja2")
-
+        self.assertTemplateUsed(response, 'hello_world.jinja')
 
 class DjangoPipelineTestTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
* Use jinja2.Template instead of django_jinja.Template