### PR TITLE
Support passing in Django template contexts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ versiontools-*.egg
 .settings
 
 doc/index.html
+.tox

--- a/README.rst
+++ b/README.rst
@@ -27,3 +27,14 @@ You can install it with pip:
 .. code-block:: shell
 
     pip install django-jinja
+
+How to run tests as a developer
+-------------------------------
+
+Install the Tox automation tool (outside a virtualenv), then
+
+.. code-block:: shell
+
+    tox
+
+Tox will create virtualenvs for different interpreter versions and run the test suite.

--- a/django_jinja/backend.py
+++ b/django_jinja/backend.py
@@ -27,6 +27,7 @@ from django.template import TemplateSyntaxError
 from django.template.backends.base import BaseEngine
 from django.template.backends.utils import csrf_input_lazy
 from django.template.backends.utils import csrf_token_lazy
+from django.template.context import BaseContext
 from django.utils import lru_cache
 from django.utils import six
 from django.utils.encoding import smart_text
@@ -66,6 +67,8 @@ class Template(object):
         if context is None:
             context = {}
 
+        context = base.dict_from_context(context)
+
         if request is not None:
             def _get_val():
                 token = get_token(request)
@@ -83,7 +86,6 @@ class Template(object):
 
         if self.backend._tmpl_debug:
             from django.test import signals
-            from django.template.context import BaseContext
 
             # Define a "django" like context for emitatet the multi
             # layered context object. This is mainly for apps like

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py27,py34,py35
+[testenv]
+changedir=testing
+commands=python runtests.py
+deps=
+    jinja2
+    django-pipeline<1.6
+    pytz


### PR DESCRIPTION
The impetus for this patch was infusing some Jinja templates into a Django-CMS based project. Django-CMS requires the use of Django templates due to some internal magic, but since [Django duck-types templates in `include` tags](https://github.com/django/django/blob/a6074e8908e36286de7e31f165be801df8ee1eab/django/template/loader_tags.py#L193-L194) one can actually pass in a Jinja template in the view's context and then `{% include %}` it.

However, since the Django context is a stack of dicts instead of a single dict, this will fail internally in Jinja, unless the stack is flattened.

Thus, those stacks are now implicitly flattened when one tries to render a Jinja template with a Django context.