### PR TITLE
Add missing truncatechars_html filter

### DIFF
--- a/django_jinja/builtins/extensions.py
+++ b/django_jinja/builtins/extensions.py
@@ -188,6 +188,7 @@ class DjangoFiltersExtension(Extension):
         environment.filters["slugify"] = filters.slugify
         environment.filters["stringformat"] = filters.stringformat
         environment.filters["truncatechars"] = filters.truncatechars
+        environment.filters["truncatechars_html"] = filters.truncatechars_html
         environment.filters["truncatewords"] = filters.truncatewords
         environment.filters["truncatewords_html"] = filters.truncatewords_html
         environment.filters["urlizetrunc"] = filters.urlizetrunc

--- a/django_jinja/builtins/filters.py
+++ b/django_jinja/builtins/filters.py
@@ -39,6 +39,7 @@ from django.template.defaultfilters import make_list
 from django.template.defaultfilters import stringformat
 from django.template.defaultfilters import title
 from django.template.defaultfilters import truncatechars
+from django.template.defaultfilters import truncatechars_html
 from django.template.defaultfilters import truncatewords
 from django.template.defaultfilters import truncatewords_html
 from django.template.defaultfilters import upper

--- a/testing/testapp/tests.py
+++ b/testing/testapp/tests.py
@@ -45,6 +45,7 @@ class RenderTemplatesTests(TestCase):
             ("{{ num|floatformat(3) }}", {'num': 34.23234}, '34.232'),
             ("{{ 'hola'|capfirst }}", {}, "Hola"),
             ("{{ 'hola mundo'|truncatechars(5) }}", {}, "ho..."),
+            ("{{ 'hola mundo'|truncatechars_html(5) }}", {}, "ho..."),
             ("{{ 'hola mundo'|truncatewords(1) }}", {}, "hola ..."),
             ("{{ 'hola mundo'|truncatewords_html(1) }}", {}, "hola ..."),
             ("{{ 'hola mundo'|wordwrap(1) }}", {}, "hola\nmundo"),


### PR DESCRIPTION
This PR adds `truncatechars_html` filter that was missing from `DjangoFiltersExtension`.