### PR TITLE
Make it compatible with Django 1.10

### DIFF
--- a/django_jinja/builtins/extensions.py
+++ b/django_jinja/builtins/extensions.py
@@ -197,7 +197,6 @@ class DjangoFiltersExtension(Extension):
         environment.filters["cut"] = filters.cut
         environment.filters["linebreaksbr"] = filters.linebreaksbr
         environment.filters["linebreaks"] = filters.linebreaks_filter
-        environment.filters["removetags"] = filters.removetags
         environment.filters["striptags"] = filters.striptags
         environment.filters["add"] = filters.add
         environment.filters["date"] = filters.date

--- a/django_jinja/builtins/filters.py
+++ b/django_jinja/builtins/filters.py
@@ -55,7 +55,6 @@ from django.template.defaultfilters import center
 from django.template.defaultfilters import cut
 from django.template.defaultfilters import linebreaks_filter
 from django.template.defaultfilters import linebreaksbr
-from django.template.defaultfilters import removetags
 from django.template.defaultfilters import striptags
 from django.template.defaultfilters import join
 from django.template.defaultfilters import length

--- a/testing/testapp/tests.py
+++ b/testing/testapp/tests.py
@@ -54,7 +54,6 @@ class RenderTemplatesTests(TestCase):
             ("{{ 'hello'|ljust(10) }}", {}, "hello     "),
             ("{{ 'hello'|rjust(10) }}", {}, "     hello"),
             ("{{ 'hello\nworld'|linebreaksbr }}", {}, "hello<br />world"),
-            ("{{ '<div>hello</div>'|removetags('div') }}", {}, "hello"),
             ("{{ '<div>hello</div>'|striptags }}", {}, "hello"),
             ("{{ list|join(',') }}", {'list':['a','b']}, 'a,b'),
             ("{{ 3|add(2) }}", {}, "5"),


### PR DESCRIPTION
As mentioned here: https://docs.djangoproject.com/en/dev/releases/1.10/ "The removetags template filter is removed." This patch simply removes `removetags` from codebase of django_jinja so it works with 1.10 too.