### PR TITLE
Fix RemovedInDjango20Warning

### DIFF
--- a/django_jinja/builtins/extensions.py
+++ b/django_jinja/builtins/extensions.py
@@ -7,8 +7,13 @@ import django
 from django.conf import settings
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.cache import cache
-from django.core.urlresolvers import NoReverseMatch
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import NoReverseMatch
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import NoReverseMatch
+    from django.core.urlresolvers import reverse
+
 from django.utils.formats import localize
 from django.utils.translation import pgettext
 from django.utils.translation import ugettext


### PR DESCRIPTION
Importing from django.core.urlresolvers is deprecated in favour of django.urls