### PR TITLE
ErrorView tmpl_name uses match_extension setting.

### DIFF
--- a/django_jinja/backend.py
+++ b/django_jinja/backend.py
@@ -145,6 +145,9 @@ class Jinja2(BaseEngine):
         newstyle_gettext = options.pop("newstyle_gettext", True)
         context_processors = options.pop("context_processors", [])
         match_extension = options.pop("match_extension", ".jinja")
+        default_extension = options.pop("default_extension", match_extension)
+        if default_extension is None:
+            default_extension = ".jinja"
         match_regex = options.pop("match_regex", None)
         environment_clspath = options.pop("environment", "jinja2.Environment")
         extra_filters = options.pop("filters", {})
@@ -197,6 +200,7 @@ class Jinja2(BaseEngine):
         self._context_processors = context_processors
         self._match_regex = match_regex
         self._match_extension = match_extension
+        self._default_extension = default_extension
         self._tmpl_debug = tmpl_debug
         self._bytecode_cache = bytecode_cache
 
@@ -207,8 +211,6 @@ class Jinja2(BaseEngine):
 
         self._initialize_thirdparty()
         self._initialize_bytecode_cache()
-
-
 
     def _initialize_bytecode_cache(self):
         if self._bytecode_cache["enabled"]:
@@ -267,6 +269,10 @@ class Jinja2(BaseEngine):
     @property
     def match_extension(self):
         return self._match_extension
+
+    @property
+    def default_extension(self):
+        return self._default_extension
 
     def from_string(self, template_code):
         return Template(self.env.from_string(template_code), self)

--- a/django_jinja/base.py
+++ b/django_jinja/base.py
@@ -1,14 +1,11 @@
 # -*- coding: utf-8 -*-
 
-import re
-import os
 import os.path as path
-from importlib import import_module
+import re
 
-import django
-from django.conf import settings
 from django.template.context import BaseContext
 from django.utils import six
+from importlib import import_module
 
 
 def dict_from_context(context):
@@ -100,6 +97,26 @@ def get_match_extension(using=None):
         engine = engines[using]
 
     return engine.match_extension
+
+
+def get_default_extension(using=None):
+    """Get the default extension used for template files.
+
+    Used in ErrorViews for example.
+    If using is given, then it defaults back to get_match_extension.
+
+    Args:
+        using: Template backend used (default: {None})
+
+    Returns:
+        Default extension used.
+        str
+    """
+    from .backend import Jinja2
+
+    if using is not None:
+        return get_match_extension(using=using)
+    return Jinja2.get_default().default_extension
 
 
 def match_template(template_name, extension, regex):

--- a/django_jinja/views/__init__.py
+++ b/django_jinja/views/__init__.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 
 import django
-
-from django.conf import settings
-from django.views.generic import View
-from django.template import loader, RequestContext
 from django import http
+from django.template import RequestContext, loader
+from django.views.generic import View
+
+from ..base import get_match_extension
 
 
 class GenericView(View):
@@ -28,6 +28,7 @@ class GenericView(View):
 
 
 class ErrorView(GenericView):
+
     def head(self, request, *args, **kwargs):
         return self.get(request, *args, **kwargs)
 
@@ -46,22 +47,24 @@ class ErrorView(GenericView):
     def patch(self, request, *args, **kwargs):
         return self.get(request, *args, **kwargs)
 
+    match_extension = get_match_extension() or ".jinja"
+
 
 class PageNotFound(ErrorView):
-    tmpl_name = "404" + getattr(settings, 'DEFAULT_JINJA2_TEMPLATE_EXTENSION', '.jinja')
+    tmpl_name = "404" + ErrorView.match_extension
     response_cls = http.HttpResponseNotFound
 
 
 class PermissionDenied(ErrorView):
-    tmpl_name = "403" + getattr(settings, 'DEFAULT_JINJA2_TEMPLATE_EXTENSION', '.jinja')
+    tmpl_name = "403" + ErrorView.match_extension
     response_cls = http.HttpResponseForbidden
 
 
 class BadRequest(ErrorView):
-    tmpl_name = "400" + getattr(settings, 'DEFAULT_JINJA2_TEMPLATE_EXTENSION', '.jinja')
+    tmpl_name = "400" + ErrorView.match_extension
     response_cls = http.HttpResponseBadRequest
 
 
 class ServerError(ErrorView):
-    tmpl_name = "500" + getattr(settings, 'DEFAULT_JINJA2_TEMPLATE_EXTENSION', '.jinja')
+    tmpl_name = "500" + ErrorView.match_extension
     response_cls = http.HttpResponseServerError

--- a/django_jinja/views/__init__.py
+++ b/django_jinja/views/__init__.py
@@ -5,7 +5,7 @@ from django import http
 from django.template import RequestContext, loader
 from django.views.generic import View
 
-from ..base import get_match_extension
+from ..base import get_default_extension
 
 
 class GenericView(View):
@@ -47,24 +47,24 @@ class ErrorView(GenericView):
     def patch(self, request, *args, **kwargs):
         return self.get(request, *args, **kwargs)
 
-    match_extension = get_match_extension() or ".jinja"
+    default_extension = get_default_extension() or ".jinja"
 
 
 class PageNotFound(ErrorView):
-    tmpl_name = "404" + ErrorView.match_extension
+    tmpl_name = "404" + ErrorView.default_extension
     response_cls = http.HttpResponseNotFound
 
 
 class PermissionDenied(ErrorView):
-    tmpl_name = "403" + ErrorView.match_extension
+    tmpl_name = "403" + ErrorView.default_extension
     response_cls = http.HttpResponseForbidden
 
 
 class BadRequest(ErrorView):
-    tmpl_name = "400" + ErrorView.match_extension
+    tmpl_name = "400" + ErrorView.default_extension
     response_cls = http.HttpResponseBadRequest
 
 
 class ServerError(ErrorView):
-    tmpl_name = "500" + ErrorView.match_extension
+    tmpl_name = "500" + ErrorView.default_extension
     response_cls = http.HttpResponseServerError


### PR DESCRIPTION
ErrorView forced the `.jinja` extension on error template files. It now uses the `match_extension` setting and defaults to `.jinja` if the value evaluates to `False`.