### PR TITLE
[FIX #94] Allows DTL to {% include %} django_jinja template on Django 1.11

### DIFF
--- a/django_jinja/backend.py
+++ b/django_jinja/backend.py
@@ -54,13 +54,13 @@ class Origin(object):
 
 class Template(object):
     def __init__(self, template, backend):
-        self.template = template
+        self._template = template
         self.backend = backend
         self.origin = Origin(name=template.filename, template_name=template.name)
 
     @property
     def name(self):
-        return self.template.name
+        return self._template.name
 
     def render(self, context=None, request=None):
         if context is None:
@@ -103,7 +103,7 @@ class Template(object):
                                            context=context)
 
 
-        return mark_safe(self.template.render(context))
+        return mark_safe(self._template.render(context))
 
 
 class Jinja2(BaseEngine):

--- a/django_jinja/backend.py
+++ b/django_jinja/backend.py
@@ -102,7 +102,6 @@ class Template(object):
             signals.template_rendered.send(sender=self, template=self,
                                            context=context)
 
-
         return mark_safe(self._template.render(context))
 
 
@@ -207,8 +206,6 @@ class Jinja2(BaseEngine):
 
         self._initialize_thirdparty()
         self._initialize_bytecode_cache()
-
-
 
     def _initialize_bytecode_cache(self):
         if self._bytecode_cache["enabled"]:

--- a/tox.ini
+++ b/tox.ini
@@ -7,3 +7,4 @@ deps=
     jinja2
     django-pipeline<1.6
     pytz
+    mock


### PR DESCRIPTION
On Django 1.11  [its internals](https://github.com/django/django/blob/1.11/django/template/loader_tags.py#L207) had changed and does some trick searching for ``template.template`` and that breaks django-jinja inclusion on another DTL template.

This renames the clashing internal of Django's Template and django-jinja Template.

The change on django-jinta is not backwards-compatible but seems more feasible to land it here than on Django's main codebase.