### PR TITLE
Support StreamingHttpResponse

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Version 2.4.2
+-------------
+
+- Added `Template.stream` method to use with StreamingHttpResponse.
+
+
 Version 2.4.1
 -------------
 

--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Version 2.4.1
+-------------
+
+- Minor improvements on `makemessages`.
+
+
 Version 2.4.0
 -------------
 

--- a/django_jinja/backend.py
+++ b/django_jinja/backend.py
@@ -63,6 +63,12 @@ class Template(object):
         )
 
     def render(self, context=None, request=None):
+        return self._process_template(self.template.render, context, request)
+
+    def stream(self, context=None, request=None):
+        return self._process_template(self.template.stream, context, request)
+
+    def _process_template(self, handler, context=None, request=None):
         if context is None:
             context = {}
 
@@ -103,7 +109,7 @@ class Template(object):
                                            template=self,
                                            context=context)
 
-        return mark_safe(self.template.render(context))
+        return handler(context)
 
 
 class Jinja2(BaseEngine):

--- a/django_jinja/backend.py
+++ b/django_jinja/backend.py
@@ -63,7 +63,7 @@ class Template(object):
         )
 
     def render(self, context=None, request=None):
-        return self._process_template(self.template.render, context, request)
+        return mark_safe(self._process_template(self.template.render, context, request))
 
     def stream(self, context=None, request=None):
         return self._process_template(self.template.stream, context, request)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ if sys.version_info < (2, 7):
 
 setup(
     name = "django-jinja",
-    version = "2.4.1",
+    version = "2.4.2",
     description = "Jinja2 templating language integrated in Django.",
     long_description = "",
     keywords = "django, jinja2",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 INSTALL_REQUIRES = [
     "jinja2 >=2.5",
-    "django >=1.8",
+    "django >=1.8, <2.0",
 ]
 
 if sys.version_info < (2, 7):

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ if sys.version_info < (2, 7):
 
 setup(
     name = "django-jinja",
-    version = "2.4.0",
+    version = "2.4.1",
     description = "Jinja2 templating language integrated in Django.",
     long_description = "",
     keywords = "django, jinja2",

--- a/testing/testapp/templates/streaming_test.jinja
+++ b/testing/testapp/templates/streaming_test.jinja
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>Streaming test</title>
+  </head>
+  <body>
+    <p>Streaming to the World from {{ name }}</p>
+  </body>
+</html>

--- a/testing/testapp/tests.py
+++ b/testing/testapp/tests.py
@@ -35,6 +35,7 @@ from django_jinja.views.generic.base import Jinja2TemplateResponseMixin
 
 from .forms import TestForm
 from .models import TestModel
+from .views import StreamingTestView
 
 
 class RenderTemplatesTests(TestCase):
@@ -300,6 +301,20 @@ class RenderTemplatesTests(TestCase):
         response = self.client.get(reverse("test-1"))
         self.assertEqual(response.context["name"], "Jinja2")
         self.assertTemplateUsed(response, 'hello_world.jinja')
+
+    def test_streaming_response(self):
+        template = "streaming_test.jinja"
+        context = {"view": StreamingTestView, "name": "Streaming Jinja2"}
+        response = self.client.get(reverse('streaming-test'))
+        self.assertEqual(response.context["name"], context["name"])
+        self.assertEqual(response.context["view"], context["view"])
+        self.assertTemplateUsed(response, template)
+        template = get_template(template)
+        self.assertEqual(
+            ''.join(response.streaming_content),
+            template.render(context)
+        )
+
 
 class DjangoPipelineTestTest(TestCase):
     def setUp(self):

--- a/testing/testapp/tests.py
+++ b/testing/testapp/tests.py
@@ -311,8 +311,8 @@ class RenderTemplatesTests(TestCase):
         self.assertTemplateUsed(response, template)
         template = get_template(template)
         self.assertEqual(
-            ''.join(response.streaming_content),
-            template.render(context)
+            b''.join(response.streaming_content),
+            template.render(context).encode()
         )
 
 

--- a/testing/testapp/urls.py
+++ b/testing/testapp/urls.py
@@ -4,6 +4,7 @@ from django.conf.urls import include, url
 from django_jinja import views
 
 from .views import BasicTestView
+from .views import StreamingTestView
 from .views import PipelineTestView
 from .views import CreateTestView, DeleteTestView, DetailTestView, UpdateTestView
 from .views import ListTestView
@@ -16,6 +17,7 @@ urlpatterns = [
     url(r"^test/404$", views.PageNotFound.as_view(), name="page-404"),
     url(r"^test/403$", views.PermissionDenied.as_view(), name="page-403"),
     url(r"^test/500$", views.ServerError.as_view(), name="page-500"),
+    url(r"^test-streaming/$", StreamingTestView.as_view(), name='streaming-test'),
 
     url(r"^testmodel/$", ListTestView.as_view()),
     url(r"^testmodel/create$", CreateTestView.as_view()),

--- a/testing/testapp/views.py
+++ b/testing/testapp/views.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from django.views.generic import View
-from django.http import HttpResponse
+from django.http import HttpResponse, StreamingHttpResponse
 from django.shortcuts import render_to_response
+from django.template import loader
 from django.template.loader import render_to_string
 
 from django_jinja.views.generic.detail import DetailView
@@ -80,3 +81,9 @@ class DateDetailTestView(DateDetailView):
     model = TestModel
     date_field = 'date'
     template_name_suffix = '_date_detail'
+
+class StreamingTestView(View):
+    def get(self, request, *args, **kwargs):
+        context = {"name": "Streaming Jinja2", "view": type(self)}
+        template = loader.get_template('streaming_test.jinja')
+        return StreamingHttpResponse(template.stream(context, request), content_type='text/html')


### PR DESCRIPTION
Basically, a wrapper for Jinja's `stream()` method and some tests.
Also, integrated orphaned commit https://github.com/niwinz/django-jinja/commit/9df156ca8ae5d52582a3325d7c7d2302917f5508
Capped max Django version at 2.0, as tests fail for it. 