### PR TITLE
support current_app as an argument for reverse

### DIFF
--- a/django_jinja/builtins/extensions.py
+++ b/django_jinja/builtins/extensions.py
@@ -19,6 +19,7 @@ from django.utils.translation import pgettext
 from django.utils.translation import ugettext
 from jinja2 import Markup
 from jinja2 import TemplateSyntaxError
+from jinja2 import contextfunction
 from jinja2 import lexer
 from jinja2 import nodes
 from jinja2.ext import Extension
@@ -157,9 +158,19 @@ class UrlsExtension(Extension):
         super(UrlsExtension, self).__init__(environment)
         environment.globals["url"] = self._url_reverse
 
+    @contextfunction
     def _url_reverse(self, name, *args, **kwargs):
         try:
-            return reverse(name, args=args, kwargs=kwargs)
+            current_app = context["request"].current_app
+        except AttributeError:
+            try:
+                current_app = context["request"].resolver_match.namespace
+            except AttributeError:
+                current_app = None
+        except KeyError:
+            current_app = None
+        try:
+            return reverse(name, args=args, kwargs=kwargs, current_app=current_app)
         except NoReverseMatch as exc:
             logger.error('Error: %s', exc)
             if not JINJA2_MUTE_URLRESOLVE_EXCEPTIONS:

--- a/django_jinja/builtins/extensions.py
+++ b/django_jinja/builtins/extensions.py
@@ -159,7 +159,7 @@ class UrlsExtension(Extension):
         environment.globals["url"] = self._url_reverse
 
     @contextfunction
-    def _url_reverse(self, name, *args, **kwargs):
+    def _url_reverse(self, context, name, *args, **kwargs):
         try:
             current_app = context["request"].current_app
         except AttributeError:


### PR DESCRIPTION
current_app has been a argument for reverse since at least django 1.7 and is part of the django template url tag, and is a requirement if you rely on current_app for your url resolving with multiple apps for instance multiple django admins. This code is pretty much exactly how django's template tag does it.