### PR TITLE
Add note that templatetags need to be in an app

### DIFF
--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -426,6 +426,7 @@ from .myextensions  import MyExtension
 library.extension(MyExtension)
 ----
 
+This only works within a Django app. If you don't have an app for your project, create an app specifically for this purpose and put your templatetags there. 
 
 === Render 4xx/500 pages with jinja
 


### PR DESCRIPTION
I had trouble with this when migrating a part of the codebase from a multi-app to a no-app project.
Maybe it's not the best place for it to be?