### PR TITLE
Fixed loading empty templatetags folders for Python 3.7.

### DIFF
--- a/django_jinja/base.py
+++ b/django_jinja/base.py
@@ -37,8 +37,8 @@ def _iter_templatetags_modules_list():
         try:
             mod = import_module(app_path + ".templatetags")
             # Empty folders can lead to unexpected behavior with Python 3.
-            # We make sure to have the `__file__` attribute.
-            if hasattr(mod, '__file__'):
+            # We make sure to have a `__file__` attribute that isn't None.
+            if getattr(mod, '__file__', None):
                 yield (app_path, path.dirname(mod.__file__))
         except ImportError:
             pass


### PR DESCRIPTION
Hello!

Four years ago in PR #86, @Exirel fixed an crash that occurred on Python 3 when any of the installed apps had an empty templatetags folder. These folders get left behind by git when modules get deleted. It did this by checking if the module returned by `import_module()` had a `__file__` attribute or not.

In Python 3.7.0, the `__file__` attribute seems to be set to `None` in the case of empty folders, rather than being unset. This contradicts [import_lib's docs](https://docs.python.org/3/reference/import.html#__file__): "If set, this attribute’s value must be a string." It's possible this is a bug on cpython's part.

This PR changes hasattr to getattr, which should consistently resolve to false on both 3.7 and pre-3.7 versions of Python.

Thanks!



