### PR TITLE
Django 2.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ matrix:
       env: TOXENV=py35-django20
     - python: 3.6
       env: TOXENV=py36-django20
+    - python: 3.5
+      env: TOXENV=py35-django21
+    - python: 3.6
+      env: TOXENV=py36-django21
 
 install:
   - pip install tox

--- a/django_jinja/builtins/extensions.py
+++ b/django_jinja/builtins/extensions.py
@@ -78,8 +78,10 @@ class CsrfExtension(Extension):
             if csrf_token == 'NOTPROVIDED':
                 return Markup("")
 
+            # Django 2.1 and higher does not render the closing slash for void elements. Emulate this behavior:
+            void_slash = ' /' if django.VERSION < (2, 1) else ''
             return Markup("<input type='hidden'"
-                          " name='csrfmiddlewaretoken' value='%s' />" % (csrf_token))
+                          " name='csrfmiddlewaretoken' value='%s'%s>" % (csrf_token, void_slash))
 
         if settings.DEBUG:
             import warnings

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     py{27,34,35,36}-django111
     py{34,35,36}-django20
+    py{35,36}-django21
 
 [testenv]
 changedir=testing
@@ -9,6 +10,7 @@ commands=python runtests.py
 deps=
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
+    django21: Django>=2.1,<2.2
     jinja2
     django-pipeline<1.6
     pytz


### PR DESCRIPTION
Hello,

This PR adds Django 2.1 to the testing suite, and modifies existing tests to be compatible with 2.1's new html style for void elements. From the release notes:

> * HTML rendered by form widgets no longer includes a closing slash on void elements, e.g. \<br\>. This is incompatible within XHTML, although some widgets already used aspects of HTML5 such as boolean attributes.

For consistency with Django's new behavior, django-jinja's implementation of `{% csrf_token %}` no longer renders the XHTML slash when running with 2.1 or higher. 

Thanks,  
Phillip Marshall