### PR TITLE
get_exception_info: fix get_exception_info for source=None

### DIFF
--- a/django_jinja/backend.py
+++ b/django_jinja/backend.py
@@ -313,7 +313,13 @@ def get_exception_info(exception):
     """
     context_lines = 10
     lineno = exception.lineno
-    lines = list(enumerate(exception.source.strip().split("\n"), start=1))
+    if exception.source is None:
+        if os.path.exists(exception.filename):
+            with open(exception.filename, "r") as f:
+                source = f.read()
+    else:
+        source = exception.source
+    lines = list(enumerate(source.strip().split("\n"), start=1))
     during = lines[lineno - 1][1]
     total = len(lines)
     top = max(0, lineno - context_lines - 1)


### PR DESCRIPTION
This might happen when a template with a base gets rendered, having the
error in the included template.

> {% extends "layout.html" %}

> {{ foo "bar" }}

> Error: ("expected token 'end of print statement', got 'string'",)

In the Jinja2 API it seems to be usual that `source` / `source_hint` can
be `None`.