### PR TITLE
Tidy up documentation a bit more, dropping Python 2.7/3.4 in the docs.

### DIFF
--- a/django_jinja/backend.py
+++ b/django_jinja/backend.py
@@ -7,8 +7,6 @@ This is an implementation of django backend inteface for use
 django_jinja easy with django 1.8.
 """
 
-from __future__ import absolute_import
-
 import copy
 import sys
 import os

--- a/django_jinja/base.py
+++ b/django_jinja/base.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import re
 import os
 import os.path as path

--- a/django_jinja/builtins/extensions.py
+++ b/django_jinja/builtins/extensions.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import logging
 import pprint
 import sys

--- a/django_jinja/builtins/filters.py
+++ b/django_jinja/builtins/filters.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 try:
     from django.utils.encoding import force_str
 except ImportError:

--- a/django_jinja/cache.py
+++ b/django_jinja/cache.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import django
 from django.utils.functional import cached_property
 from jinja2 import BytecodeCache as _BytecodeCache

--- a/django_jinja/contrib/_easy_thumbnails/templatetags/thumbnails.py
+++ b/django_jinja/contrib/_easy_thumbnails/templatetags/thumbnails.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import logging
 
 from easy_thumbnails.conf import settings

--- a/django_jinja/contrib/_humanize/templatetags/_humanize.py
+++ b/django_jinja/contrib/_humanize/templatetags/_humanize.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from django.contrib.humanize.templatetags import humanize
 from django_jinja import library
 

--- a/django_jinja/contrib/_pipeline/templatetags/_pipeline.py
+++ b/django_jinja/contrib/_pipeline/templatetags/_pipeline.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import unicode_literals, absolute_import
-
 import jinja2
 
 from django.contrib.staticfiles.storage import staticfiles_storage

--- a/django_jinja/contrib/_subdomains/templatetags/subdomainurls.py
+++ b/django_jinja/contrib/_subdomains/templatetags/subdomainurls.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from django_jinja import library
 from jinja2 import contextfunction
 from subdomains.templatetags.subdomainurls import url as subdomain_url

--- a/django_jinja/utils.py
+++ b/django_jinja/utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import functools
 from importlib import import_module
 

--- a/django_jinja/views/__init__.py
+++ b/django_jinja/views/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import django
 from django import http
 from django.template import RequestContext, loader

--- a/django_jinja/views/generic/base.py
+++ b/django_jinja/views/generic/base.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from ...base import get_match_extension
 
 

--- a/django_jinja/views/generic/dates.py
+++ b/django_jinja/views/generic/dates.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from django.views.generic.dates import ArchiveIndexView as _django_ArchiveIndexView
 from django.views.generic.dates import YearArchiveView as _django_YearArchiveView
 from django.views.generic.dates import MonthArchiveView as _django_MonthArchiveView

--- a/django_jinja/views/generic/detail.py
+++ b/django_jinja/views/generic/detail.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from django.views.generic.detail import DetailView as _django_DetailView
 
 from .base import Jinja2TemplateResponseMixin

--- a/django_jinja/views/generic/edit.py
+++ b/django_jinja/views/generic/edit.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from django.views.generic.edit import CreateView as _django_CreateView
 from django.views.generic.edit import DeleteView as _django_DeleteView
 from django.views.generic.edit import UpdateView as _django_UpdateView

--- a/django_jinja/views/generic/list.py
+++ b/django_jinja/views/generic/list.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from django.views.generic.list import ListView as _django_ListView
 
 from .base import Jinja2TemplateResponseMixin

--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -10,7 +10,7 @@ Andrey Antukh, <niwi@niwi.be>
 
 == Introduction
 
-django-jinja is a xref:license[BSD Licensed], simple and nonobstructive jinja2
+django-jinja is a xref:license[BSD Licensed], simple and non-obstructive jinja2
 backend for Django.
 
 
@@ -23,9 +23,9 @@ system, etc ...
 Django comes with a jinja backend, why should I use *django-jinja*?
 
 The Django builtin backend has a very limited set of features if we compare it with
-the django template engine and in my opion is not very usable because it does not
+the django template engine and in my opinion is not very usable because it does not
 integrate well with the rest of django such as its filters, template tags and
-preloading of templatetags among others.
+preloading of templatetags, among others.
 
 *django-jinja* comes to the rescue and adds everything missing. This is a brief
 list of differences with django's built-in backend:
@@ -38,7 +38,7 @@ list of differences with django's built-in backend:
 - Django template filters and tags can mostly be used in Jinja2 templates.
 - I18n subsystem adapted for Jinja2 (makemessages now collects messages from
   Jinja templates)
-- Compatible with python2 and python3 using same codebase.
+- Compatible with python2 and python3 using the same codebase.
 - jinja2 bytecode cache adapted for using django's cache subsystem.
 - Support for django context processors.
 
@@ -53,7 +53,7 @@ in the django 1.8 configuration related section.
 
 === Requirements
 
-- Python 2.7, 3.4 and 3.5
+- Python 2.7, 3.4+
 - Django >= 1.8
 - jinja2 >= 2.7.0
 
@@ -72,7 +72,7 @@ pip install django-jinja
 
 == Quick Start
 
-Add it to django installed apps list:
+Add it to Django's installed apps list:
 
 [source, python]
 ----
@@ -114,8 +114,8 @@ template will be found by the django engine.
 
 === Regex based template matching
 
-By default, *django-jinja* uses the extension as method to match templates, but if
-it is not enough, you can extend it using regular experessions:
+By default, *django-jinja* uses the file extension as the method to match
+templates, but if it is not enough, you can extend it using regular expressions:
 
 [source, python]
 ----
@@ -140,7 +140,7 @@ To disable the extension matching, just set `"match_extension"` to `None`:
 It is a helper to use django's context processors with jinja2 backend
 for django 1.8.
 
-.Example setup a bunch of context processors:
+.Example: set up a bunch of context processors:
 [source, python]
 ----
 "OPTIONS": {
@@ -163,8 +163,8 @@ for migrations.
 
 [NOTE]
 ====
-Remeber that django (1.8.x and 1.9.x) is backward compatibile with
-the old template api and this has its own tradeoffs. If you find yourself using functions
+Remember that django (1.8.x and 1.9.x) is backward compatible with
+the old template api and this has its own trade-offs. If you find yourself using functions
 like `render_to_string` or `render_to_response` from django, do not forget to pass the
 request parameter in order to make context processors work.
 ====
@@ -368,7 +368,7 @@ The affected filters are: title, upper, lower, urlencode, urlize, wordcount, wor
 join, length, random, default, filesizeformat, pprint.
 
 
-=== Registring filters in a "django" way.
+=== Registering filters in a "django" way.
 
 django-jinja comes with facilities for loading template filters, globals and tests
 from django applications.
@@ -427,7 +427,7 @@ from .myextensions  import MyExtension
 library.extension(MyExtension)
 ----
 
-This only works within a Django app. If you don't have an app for your project, create an app specifically for this purpose and put your templatetags there. 
+This only works within a Django app. If you don't have an app for your project, create an app specifically for this purpose and put your templatetags there.
 
 === Render 4xx/500 pages with jinja
 

--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -53,7 +53,7 @@ in the django 1.8 configuration related section.
 
 === Requirements
 
-- Python 2.7, 3.4+
+- Python >= 3.5
 - Django >= 1.8
 - jinja2 >= 2.7.0
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 from setuptools import setup
 import sys

--- a/setup.py
+++ b/setup.py
@@ -53,13 +53,11 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Internet :: WWW/HTTP",
     ]
 )

--- a/testing/runtests.py
+++ b/testing/runtests.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import os, sys
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
 

--- a/testing/testapp/migrations/0001_initial.py
+++ b/testing/testapp/migrations/0001_initial.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import models, migrations
 
 

--- a/testing/testapp/migrations/0002_testmodel_date.py
+++ b/testing/testapp/migrations/0002_testmodel_date.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import models, migrations
 
 

--- a/testing/testapp/models.py
+++ b/testing/testapp/models.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from django.db.models import Model, DateTimeField
 
 

--- a/testing/testapp/tests.py
+++ b/testing/testapp/tests.py
@@ -1,8 +1,3 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import datetime
 
 try:

--- a/testing/testapp/urls.py
+++ b/testing/testapp/urls.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from django.conf.urls import include, url
 from django_jinja import views
 

--- a/testing/testapp/views.py
+++ b/testing/testapp/views.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from django.views.generic import View
 from django.http import HttpResponse, StreamingHttpResponse
 from django.shortcuts import render_to_response


### PR DESCRIPTION
Fixes to typos, grammar improvements, etc.

I took the liberty of rebasing #227 onto master, removing merge conflicts. 
@adamchainz was kept as the author as I figured that was appropriate.

I also removed python 3.4 support in the docs, as I saw that was recently dropped.

Edit: I marked python 2.7 as dropped as well, as it was dropped before 2.5.0 in the merge of PR #237. Sorry for all the force pushing.