### PR TITLE
explicit version support in docs, changelog, test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,16 @@ matrix:
       env: TOXENV=py36-django22
     - python: 3.7
       env: TOXENV=py37-django22
+    - python: 3.8
+      env: TOXENV=py38-django22
+    - python: 3.5
+      env: TOXENV=py35-django30
+    - python: 3.6
+      env: TOXENV=py36-django30
+    - python: 3.7
+      env: TOXENV=py37-django30
+    - python: 3.8
+      env: TOXENV=py38-django30
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ matrix:
       env: TOXENV=py37-django22
     - python: 3.8
       env: TOXENV=py38-django22
-    - python: 3.5
-      env: TOXENV=py35-django30
     - python: 3.6
       env: TOXENV=py36-django30
     - python: 3.7

--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Version 2.5.0
+-------------
+
+- Fix compatibility issues with Django 3.0, minimum version now 1.11.
+- Dropped support for Python 2.7, 3.4, adding support through 3.8.
+
+
 Version 2.4.2
 -------------
 

--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -71,7 +71,7 @@ If you are using older versions of Django or Python, you need an older version o
 |1.8, 1.11
 
 |>=2.5.0
-|3.5, 3.6, 3.7, 3.8
+|3.5 (not django 3.0), 3.6, 3.7, 3.8
 |1.11, 2.2, 3.0
 |===
 

--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -54,10 +54,26 @@ in the django 1.8 configuration related section.
 === Requirements
 
 - Python >= 3.5
-- Django >= 1.8
+- Django >= 1.11
 - jinja2 >= 2.7.0
 
-*If you are using django < 1.8, you should use django-jinja 1.x versions.*
+If you are using older versions of Django or Python, you need an older version of django-jinja:
+
+|===
+|django-jinja |supported python versions |supported django versions
+
+|==1.4.2
+|2.7, 3.3, 3.4
+|1.5, 1.6, 1.7, 1.8
+
+|==2.4.1
+|2.7, 3.4, 3.5
+|1.8, 1.11
+
+|>=2.5.0
+|3.5, 3.6, 3.7, 3.8
+|1.11, 2.2, 3.0
+|===
 
 
 === Installation

--- a/testing/testapp/views.py
+++ b/testing/testapp/views.py
@@ -1,6 +1,6 @@
 from django.views.generic import View
 from django.http import HttpResponse, StreamingHttpResponse
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.template import loader
 from django.template.loader import render_to_string
 
@@ -21,11 +21,11 @@ class BasicTestView(View):
 
 class PipelineTestView(View):
     def get(self, request, data=None):
-        return render_to_response("pipeline_test.jinja", request=request)
+        return render(request, "pipeline_test.jinja")
 
 class ContextManipulationTestView(View):
     def get(self, request):
-        return render(request, "hello_world.jinja", {"name": "Jinja2"}, request=request)
+        return render(request, "hello_world.jinja", {"name": "Jinja2"})
 
 # ==== generic.detail ====
 class DetailTestView(DetailView):

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     py{35,36}-django111
     py{35,36,37,38}-django22
-    py{35,36,37,38}-django30
+    py{36,37,38}-django30
 
 [testenv]
 changedir=testing

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
     py{35,36}-django111
-    py{35,36,37}-django22
+    py{35,36,37,38}-django22
+    py{35,36,37,38}-django30
 
 [testenv]
 changedir=testing
@@ -9,6 +10,7 @@ commands=python runtests.py
 deps=
     django111: Django>=1.11,<2.0
     django22: Django>=2.2,<3.0
+    django30: Django>=3.0,<3.1
     jinja2
     django-pipeline<1.6
     pytz


### PR DESCRIPTION
django 3.0 dropped support for python 3.5, so the expanded tests here might fail. fingers crossed.