### PR TITLE
allow for backslashes in template_name on windows

### DIFF
--- a/django_jinja/backend.py
+++ b/django_jinja/backend.py
@@ -285,6 +285,15 @@ class Jinja2(BaseEngine):
         try:
             return Template(self.env.get_template(template_name), self)
         except jinja2.TemplateNotFound as exc:
+            # Unlike django's template engine, jinja2 doesn't like windows-style path separators.
+            # But because django does, its docs encourage the usage of os.path.join().
+            # Rather than insisting that our users switch to posixpath.join(), this try block
+            # will attempt to retrieve the template path again with forward slashes on windows:
+            if os.name == 'nt' and '\\' in template_name:
+                try:
+                    return self.get_template(template_name.replace("\\", "/"))
+                except jinja2.TemplateNotFound:
+                    pass
 
             if utils.DJANGO_18:
                 exc = TemplateDoesNotExist(exc.name)


### PR DESCRIPTION
This pull request fixes finding template paths with backslashes in windows environments.

While I use linux to build and run my django project, I recently did some work getting it to run on windows, so that other non-posix people in my office could contribute. Having this change in place would have saved me a lot of time tracing through callstacks, so I figured I would share it.

It is common to see code on the internet encouraging the use of `os.path.join()` for creating paths to django templates, as the django template engine works with whatever slashes the OS uses. Jinja2, on the other hand, will only work with forward-slash style paths.

Due to the way Django will move on to the next available template engine if ours gives a TemplateNotFound error, it does not do a very good job at surfacing this kind of mistake, instead passing the template to the django template engine, and failing with a syntax error.

Rather than creating more work for django-jinja users ("be sure to use os.path.join everywhere you use django templates, and posixpath.join everywhere you use jinja templates!"), this pull request just fixes these backslash paths when django-jinja can't find a template in windows, and tries again.

---

If this change is deemed out of scope (as we don't really advertise or test windows support),
or is otherwise rejected, readers can feel free to use this shim I wrote to get my project to work on windows, and I'll leave it at that: 

    from django_jinja.backend import Jinja2

    class Jinja2Backslasher(Jinja2):
        """Transforms template_name backslashes for Windows compatibility."""

        def get_template(self, template_name):
            # example: 'path/to\\some.jinja' -> 'path/to/some.jinja'
            template_name = template_name.replace("\\", "/")
            return super(Jinja2Backslasher, self).get_template(template_name)

Then, in settings.py, change the backend here from `"django_jinja.backend.Jinja2"`:

    TEMPLATES = [
        {
            "BACKEND": "your.project.Jinja2Backslasher",
            "NAME": "jinja2",
