### PR TITLE
Added Django's json_script filter for Django 2.1 and higher.

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -5,6 +5,7 @@ Unreleased Changes
 ------------------
 
 - Fixed loading template names with backslashes on Windows (#249).
+- Added Django's `json_script` filter for Django 2.1 and higher.
 
 
 Version 2.6.0

--- a/django_jinja/builtins/extensions.py
+++ b/django_jinja/builtins/extensions.py
@@ -242,6 +242,11 @@ class DjangoFiltersExtension(Extension):
         environment.filters["localtime"] = filters.localtime
         environment.filters["utc"] = filters.utc
         environment.filters["timezone"] = filters.timezone
+        try:
+            environment.filters["json_script"] = filters.json_script
+        except AttributeError:
+            # django version < 2.1
+            pass
 
 
 class DjangoExtraFiltersExtension(Extension):

--- a/django_jinja/builtins/filters.py
+++ b/django_jinja/builtins/filters.py
@@ -78,3 +78,9 @@ linebreaksbr = partial(linebreaksbr, autoescape=True)
 from django.templatetags.tz import do_timezone as timezone
 from django.templatetags.tz import localtime
 from django.templatetags.tz import utc
+
+try:
+    from django.template.defaultfilters import json_script
+except ImportError:
+    # django version < 2.1
+    pass


### PR DESCRIPTION
This patch adds [json_script](https://docs.djangoproject.com/en/2.1/ref/templates/builtins/#json-script), the long lost sibling of the django template filters family, to django-jinja. 

Django's docs show using the script this way:

```
{{ value|json_script:"hello-data" }}
```

To use it in Jinja2, this translates to:

```
{{ value|json_script("hello-data") }}
```

django-jinja still supports django as far back as 1.11, before this filter was added in 2.1, so it will try and give up if the import doesn't work. Expect `jinja2.exceptions.TemplateAssertionError` to be raised if you try and use this filter in django 1.11.

To use `json_script` with django-jinja before this patch lands in your project, hook it up yourself in settings.py:

```
TEMPLATES = [{
    "BACKEND": "django_jinja.backend.Jinja2",
    "NAME": "jinja2",
    "OPTIONS": {
        "filters": {
            "json_script": "django.template.defaultfilters.json_script",
            ...
```