### PR TITLE
Django 3.1 is supported

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 INSTALL_REQUIRES = [
     "jinja2 >=2.10",
-    "django >=1.11, <3.1",
+    "django >=1.11, <4.0",
 ]
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,8 @@ commands=python runtests.py
 deps=
     django111: Django>=1.11,<2.0
     django22: Django>=2.2,<3.0
-    django30: Django>=3.0,<4.0
+    django30: Django>=3.0,<3.1
+    django31: Django==3.1
     jinja2
     django-pipeline<1.6
     pytz

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     py{35,36}-django111
     py{35,36,37,38}-django22
     py{36,37,38}-django30
+    py{36,37,38}-django31
 
 [testenv]
 changedir=testing

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ commands=python runtests.py
 deps=
     django111: Django>=1.11,<2.0
     django22: Django>=2.2,<3.0
-    django30: Django>=3.0,<3.1
+    django30: Django>=3.0,<4.0
     jinja2
     django-pipeline<1.6
     pytz

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps=
     django111: Django>=1.11,<2.0
     django22: Django>=2.2,<3.0
     django30: Django>=3.0,<3.1
-    django31: Django==3.1
+    django31: Django>=3.1,<3.2
     jinja2
     django-pipeline<1.6
     pytz


### PR DESCRIPTION
The latest commit on master (https://github.com/niwinz/django-jinja/commit/7d08e5d5d7cad5c00b65fd7c4b4f095f209a4162) fixes an import issue for Django 3.1, but the setup.py file still says the install requirement is "django >=1.11, <3.1".  This means dependency resolvers are incorrectly failing.