### PR TITLE
Clarify usage of context processors in the docs

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -7,6 +7,7 @@ Unreleased Changes
 - Fixed loading template names with backslashes on Windows (#249).
 - Added Django's `json_script` filter for Django 2.1 and higher.
 - Fixed docs site stylesheet.
+- Clarified "not recommended" usage of context processors with django-jinja in the docs.
 
 
 Version 2.6.0

--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -44,9 +44,10 @@ list of differences with django's built-in backend:
 
 [NOTE]
 ====
-The usage of context processors is not the recommended way anymore, and with
-*django-jinja* you can done it setting global data or global constants. See below,
-in the django 1.8 configuration related section.
+The usage of context processors is available for compatibility and migrations,
+but creating new context processors is not the recommended way to set global context.
+With *django-jinja*, you can do this by setting global data or global constants. See below,
+in the "Custom filters, globals, constants and tests" section.
 ====
 
 
@@ -171,10 +172,11 @@ for django 1.8.
 }
 ----
 
-As usual, this is a default list of context processors and you can skip
-setting them if you do not have your own. Furthermore, it is now not the recommended way
-to setup variables in the context and the purpose of its existence is a help
-for migrations.
+As with the django template engine, this is a default list of context processors, and you can skip
+setting them if you do not have your own.
+Furthermore, the purpose of django-jinja's context manager support is to help with migrations,
+but context managers are no longer the recommended way to set global variables and functions.
+For the recommended way, see the next section.
 
 [NOTE]
 ====
@@ -187,7 +189,7 @@ request parameter in order to make context processors work.
 
 === Custom filters, globals, constants and tests
 
-This is a way to setup statically (in your settings) additional stuff for jinja:
+This is the recommended way to set up additional jinja variables, tests, and filters, in your settings.
 
 [source, python]
 ----


### PR DESCRIPTION
I modified the docs in response to #261 and #235. I believe this will make django-jinja's intended usage less confusing.