### PR TITLE
Fleshed out compatibility with Django 3.1, Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,24 @@ matrix:
       env: TOXENV=py37-django22
     - python: 3.8
       env: TOXENV=py38-django22
+    - python: 3.9
+      env: TOXENV=py39-django22
     - python: 3.6
       env: TOXENV=py36-django30
     - python: 3.7
       env: TOXENV=py37-django30
     - python: 3.8
       env: TOXENV=py38-django30
+    - python: 3.9
+      env: TOXENV=py39-django30
+    - python: 3.6
+      env: TOXENV=py36-django31
+    - python: 3.7
+      env: TOXENV=py37-django31
+    - python: 3.8
+      env: TOXENV=py38-django31
+    - python: 3.9
+      env: TOXENV=py39-django31
 
 install:
   - pip install tox

--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -7,6 +7,7 @@ Unreleased Changes
 - Fixed loading template names with backslashes on Windows (#249).
 - Added Django's `json_script` filter for Django 2.1 and higher.
 - Fixed docs site stylesheet.
+- Added Django 3.1 support.
 
 
 Version 2.6.0

--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -8,6 +8,7 @@ Unreleased Changes
 - Added Django's `json_script` filter for Django 2.1 and higher.
 - Fixed docs site stylesheet.
 - Added Django 3.1 support.
+- Added Python 3.9 (rc1) to test suite.
 
 
 Version 2.6.0

--- a/django_jinja/backend.py
+++ b/django_jinja/backend.py
@@ -23,7 +23,7 @@ from django.template import TemplateDoesNotExist
 from django.template import TemplateSyntaxError
 from django.template.backends.base import BaseEngine
 from django.template.context import BaseContext
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 from django.utils.functional import SimpleLazyObject
 from django.utils.functional import cached_property
 from django.utils.module_loading import import_string
@@ -73,7 +73,7 @@ class Template(object):
                 if token is None:
                     return 'NOTPROVIDED'
                 else:
-                    return smart_text(token)
+                    return smart_str(token)
 
             context["request"] = request
             context["csrf_token"] = SimpleLazyObject(_get_val)

--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -70,8 +70,12 @@ If you are using older versions of Django or Python, you need an older version o
 |1.8, 1.11
 
 |>=2.5.0
-|3.5 (not django 3.0), 3.6, 3.7, 3.8
+|3.5 (not django 3.x), 3.6, 3.7, 3.8
 |1.11, 2.2, 3.0
+
+|Unreleased
+|3.5 (not django 3.x), 3.6, 3.7, 3.8
+|1.11, 2.2, 3.0, 3.1
 |===
 
 

--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -74,7 +74,7 @@ If you are using older versions of Django or Python, you need an older version o
 |1.11, 2.2, 3.0
 
 |Unreleased
-|3.5 (not django 3.x), 3.6, 3.7, 3.8
+|3.5 (not django 3.x), 3.6, 3.7, 3.8, 3.9
 |1.11, 2.2, 3.0, 3.1
 |===
 

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Internet :: WWW/HTTP",
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
     py{35,36}-django111
-    py{35,36,37,38}-django22
-    py{36,37,38}-django30
-    py{36,37,38}-django31
+    py{35,36,37,38,39}-django22
+    py{36,37,38,39}-django30
+    py{36,37,38,39}-django31
 
 [testenv]
 changedir=testing


### PR DESCRIPTION
Django 3.1 support was fixed in PR #262. This branch adds onto that by adding python 3.9 support (it just hit rc1), updating tox/travis testing matrices, and updating the docs to indicate new support.

I also added the classifier "Programming Language :: Python :: 3 :: Only" to setup.py, as we no longer support python 2.

Oh and this fixes #258 by changing django.utils.encoding.smart_str to smart_text.