### PR TITLE
Adding ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ cache: pip
 
 matrix:
   include:
-    - python: 3.5
-      env: TOXENV=py35-django22
     - python: 3.6
       env: TOXENV=py36-django22
     - python: 3.7
@@ -30,6 +28,43 @@ matrix:
       env: TOXENV=py38-django31
     - python: 3.9
       env: TOXENV=py39-django31
+    # Adding jobs for ppc64le
+    - python: 3.6
+      env: TOXENV=py36-django22
+      arch: ppc64le
+    - python: 3.7
+      env: TOXENV=py37-django22
+      arch: ppc64le
+    - python: 3.8
+      env: TOXENV=py38-django22
+      arch: ppc64le
+    - python: 3.9
+      env: TOXENV=py39-django22
+      arch: ppc64le
+    - python: 3.6
+      env: TOXENV=py36-django30
+      arch: ppc64le
+    - python: 3.7
+      env: TOXENV=py37-django30
+      arch: ppc64le
+    - python: 3.8
+      env: TOXENV=py38-django30
+      arch: ppc64le
+    - python: 3.9
+      env: TOXENV=py39-django30
+      arch: ppc64le
+    - python: 3.6
+      env: TOXENV=py36-django31
+      arch: ppc64le
+    - python: 3.7
+      env: TOXENV=py37-django31
+      arch: ppc64le
+    - python: 3.8
+      env: TOXENV=py38-django31
+      arch: ppc64le
+    - python: 3.9
+      env: TOXENV=py39-django31
+      arch: ppc64le
 
 install:
   - pip install tox


### PR DESCRIPTION
Hi,
I had added ppc64le architecture support on travis-ci and looks like its been successfully added. Jobs depending on python3.9 is switched to python3.9-dev as python3.9 is still not supported on travis ci. I believe it is ready for the final review and merge.

Please have a look.

Thanks!!
Kishor Kunal Raj