### PR TITLE
add None value for cache extension

### DIFF
--- a/django_jinja/builtins/extensions.py
+++ b/django_jinja/builtins/extensions.py
@@ -94,10 +94,11 @@ class CacheExtension(Extension):
 
     def _cache_support(self, expire_time, fragm_name, vary_on, lineno, caller):
         try:
-            expire_time = int(expire_time)
+            if expire_time is not None:
+                expire_time = int(expire_time)
         except (ValueError, TypeError):
             raise TemplateSyntaxError('"%s" tag got a non-integer timeout '
-                'value: %r' % (list(self.tags)[0], expire_time), lineno)
+                                      'value: %r' % (list(self.tags)[0], expire_time), lineno)
 
         cache_key = make_template_fragment_key(fragm_name, vary_on)
 


### PR DESCRIPTION
As Django docs said [The fragment is cached forever if timeout is None](https://docs.djangoproject.com/en/3.1/topics/cache/#template-fragment-caching). However when I set timeout to None get this error:
`"cache" tag got a non-integer timeout value: None`. So I made a little fix.