### PR TITLE
Let README displayed on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     version = "2.7.0",
     description = "Jinja2 templating language integrated in Django.",
     long_description = open("README.rst").read(),
-    long_description_content_type='text/markdown',
+    long_description_content_type='text/x-rst',
     keywords = "django, jinja2",
     author = "Andrey Antukh",
     author_email = "niwi@niwi.be",


### PR DESCRIPTION
Currently, this is how it is displayed on PyPI:

![image](https://user-images.githubusercontent.com/314607/111858053-7eb00100-8968-11eb-8ed7-d5c2208c837e.png)
