### PR TITLE
v2.7.1

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -1,12 +1,13 @@
 Changelog
 =========
 
-Unreleased
-----------
+Version 2.7.1
+-------------
 
-- Fixed makemessages command not reading Django template `{% trans %}` tags correctly (#272).
-- Fixed `{% cache %}` tag to allow None timeout to cache forever, which Django allowed since in 2.0.
-- Added testing against Django 3.2b1.
+- Fixed `makemessages` command, which in 2.7.0 could not detect `{% trans %}` tags in Django templates (#272).
+- Fixed `{% cache %}` tag to allow a timeout of `None` (to cache forever), which Django's tag added in 2.0 (#274).
+- Fixed README not displaying in project description at PyPI (#276).
+- Added Django 3.2 support.
 
 
 Version 2.7.0

--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -1,6 +1,6 @@
 = django-jinja - jinja2 backend for Django
 Andrey Antukh, <niwi@niwi.be>
-2.7.0
+2.7.1
 :toc: left
 :!numbered:
 :source-highlighter: pygments
@@ -76,7 +76,7 @@ If you are using older versions of Django or Python, you need an older version o
 
 |>=2.7.0
 |3.5 (django 2.2 only), 3.6, 3.7, 3.8, 3.9
-|2.2, 3.0, 3.1, 3.2b1
+|2.2, 3.0, 3.1, 3.2
 |===
 
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name = "django-jinja",
-    version = "2.7.0",
+    version = "2.7.1",
     description = "Jinja2 templating language integrated in Django.",
     long_description = open("README.rst").read(),
     long_description_content_type='text/x-rst',

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps=
     django22: Django>=2.2,<3.0
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
-    django32: Django==3.2b1
+    django32: Django>=3.2,<4.0
     jinja2
     django-pipeline<1.6
     pytz


### PR DESCRIPTION
Django has recently released version 3.2. There are no changes necessitated by it, but I've updated the docs and test grid to keep up with it.

Since we have some recent bug fixes contributed, let's put those out in a release, as well as to declare support for 3.2.

Version 2.7.1
-------------

- Fixed `makemessages` command, which in 2.7.0 could not detect `{% trans %}` tags in Django templates (#272).
- Fixed `{% cache %}` tag to allow a timeout of `None` (to cache forever), which Django's tag added in 2.0 (#274).
- Fixed README not displaying in project description at PyPI (#276).
- Added Django 3.2 support.