### PR TITLE
v2.8.0

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -1,9 +1,10 @@
 Changelog
 =========
 
-Unreleased
-----------
+Version 2.8.0
+-------------
 
+- Upgrade to jinja2 3.0, dropping support for 2.11 and below (#279).
 - Dropped Python 3.5 support.
 
 

--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- Dropped Python 3.5 support.
+
+
 Version 2.7.1
 -------------
 

--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -53,7 +53,7 @@ in the "Custom filters, globals, constants and tests" section.
 
 === Requirements
 
-- Python >= 3.5
+- Python >= 3.6
 - Django >= 2.2
 - jinja2 >= 2.10
 

--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -1,6 +1,6 @@
 = django-jinja - jinja2 backend for Django
 Andrey Antukh, <niwi@niwi.be>
-2.7.1
+2.8.0
 :toc: left
 :!numbered:
 :source-highlighter: pygments
@@ -76,6 +76,10 @@ If you are using older versions of Django or Python, you need an older version o
 
 |>=2.7.0
 |3.5 (django 2.2 only), 3.6, 3.7, 3.8, 3.9
+|2.2, 3.0, 3.1, 3.2
+
+|>=2.8.0
+|3.6, 3.7, 3.8, 3.9
 |2.2, 3.0, 3.1, 3.2
 |===
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name = "django-jinja",
-    version = "2.7.1",
+    version = "2.8.0",
     description = "Jinja2 templating language integrated in Django.",
     long_description = open("README.rst").read(),
     long_description_content_type='text/x-rst',

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "django_jinja.views",
         "django_jinja.views.generic",
     ],
-    python_requires = ">=3.5",
+    python_requires = ">=3.6",
     install_requires = [
         "jinja2>=3",
         "django>=2.2",
@@ -53,7 +53,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{35,36,37,38,39}-django22
+    py{36,37,38,39}-django22
     py{36,37,38,39}-django30
     py{36,37,38,39}-django31
     py{36,37,38,39}-django32


### PR DESCRIPTION
jinja2 has recently released version 3, and thanks to @tomhamiltonstubber's patch, django-jinja now works with it.

Since this is a major version bump for jinja2 (and these changes drop version 2.11 support), I figured I would increment to 2.8.0. I also took the opportunity to fully drop Python 3.5, which is no longer receiving security updates.

Version 2.8.0
-------------

- Upgrade to jinja2 3.0, dropping support for 2.11 and below (#279).
- Dropped Python 3.5 support.