### PR TITLE
Mark as compatible with Python 3.6+

### DIFF
--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -53,7 +53,7 @@ in the "Custom filters, globals, constants and tests" section.
 
 === Requirements
 
-- Python >= 3.5
+- Python >= 3.6
 - Django >= 2.2
 - jinja2 >= 2.10
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "django_jinja.views",
         "django_jinja.views.generic",
     ],
-    python_requires = ">=3.5",
+    python_requires = ">=3.6",
     install_requires = [
         "jinja2>=3",
         "django>=2.2",
@@ -53,7 +53,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{35,36,37,38,39}-django22
+    py{36,37,38,39}-django22
     py{36,37,38,39}-django30
     py{36,37,38,39}-django31
     py{36,37,38,39}-django32


### PR DESCRIPTION
Jinja2 3.x is not compatible with 3.5 anyway.