### PR TITLE
added jinja2 policies in template options, makemessages respects ext.i18n.trimmed policy

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -5,6 +5,8 @@ Unreleased
 ----------
 
 - Jinja2 policies now settable via TEMPLATES[n]['OPTIONS']['policies'] (#285).
+- `makemessages` now respects the `ext.i18n.trimmed` policy,
+   will automatically trim jinja `{% trans %}` blocks when generating `.po` files.
 
 
 Version 2.8.0

--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- Jinja2 policies now settable via TEMPLATES[n]['OPTIONS']['policies'] (#285).
+
+
 Version 2.8.0
 -------------
 

--- a/django_jinja/backend.py
+++ b/django_jinja/backend.py
@@ -151,6 +151,7 @@ class Jinja2(BaseEngine):
         extra_globals = options.pop("globals", {})
         extra_constants = options.pop("constants", {})
         translation_engine = options.pop("translation_engine", "django.utils.translation")
+        policies = options.pop("policies", {})
 
         tmpl_debug = options.pop("debug", settings.DEBUG)
         bytecode_cache = options.pop("bytecode_cache", {})
@@ -203,6 +204,7 @@ class Jinja2(BaseEngine):
                                   tests=extra_tests,
                                   globals=extra_globals,
                                   constants=extra_constants)
+        self._initialize_policies(policies)
 
         self._initialize_thirdparty()
         self._initialize_bytecode_cache()
@@ -256,6 +258,11 @@ class Jinja2(BaseEngine):
         if constants:
             for name, value in constants.items():
                 self.env.globals[name] = value
+
+    def _initialize_policies(self, policies):
+        # Set policies like those in jinja2.defaults.DEFAULT_POLICIES
+        for name, value in policies.items():
+            self.env.policies[name] = value
 
     @cached_property
     def context_processors(self):

--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -37,7 +37,7 @@ list of differences with django's built-in backend:
   It works as middleware, intercepts Jinja templates by file path pattern.
 - Django template filters and tags can mostly be used in Jinja2 templates.
 - I18n subsystem adapted for Jinja2 (makemessages now collects messages from
-  Jinja templates)
+  Jinja templates, respects the `ext.i18n.trimmed` policy)
 - jinja2 bytecode cache adapted for using django's cache subsystem.
 - Support for django context processors.
 

--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -218,6 +218,20 @@ This is the recommended way to set up additional jinja variables, tests, and fil
 ----
 
 
+=== Set policies
+
+To set link:https://jinja.palletsprojects.com/en/3.0.x/api/#policies[environment policies] introduced in Jinja2 2.9:
+
+[source, python]
+----
+"OPTIONS": {
+    "policies": {
+        "ext.i18n.trimmed": True,
+    },
+}
+----
+
+
 === Add additional extensions
 
 django-jinja, by default sets up a great amount of extensions to make your experience
@@ -301,6 +315,7 @@ TEMPLATES = [
             "constants": {
                 "foo": "bar",
             },
+            "policies": {},
             "extensions": [
                 "jinja2.ext.do",
                 "jinja2.ext.loopcontrols",

--- a/testing/locale/en/LC_MESSAGES/django.po
+++ b/testing/locale/en/LC_MESSAGES/django.po
@@ -1,4 +1,4 @@
-#: testapp/templates/i18n_test.html:1 testapp/templates/i18n_test.jinja:1
+#: testapp/templates/i18n_test.html:1
 #, python-format
 msgid ""
 "\n"
@@ -26,7 +26,7 @@ msgid ""
 "3 This is %(book_title)s by %(author)s\n"
 msgstr ""
 
-#: testapp/templates/i18n_test.html:20 testapp/templates/i18n_test.jinja:19
+#: testapp/templates/i18n_test.html:20
 #, python-format
 msgid ""
 "\n"
@@ -41,7 +41,7 @@ msgstr[1] ""
 msgid "5 Hello World!"
 msgstr ""
 
-#: testapp/templates/i18n_test.html:33 testapp/templates/i18n_test.jinja:32
+#: testapp/templates/i18n_test.html:33
 #, python-format
 msgid ""
 "\n"
@@ -56,5 +56,24 @@ msgstr[1] ""
 #, python-format
 msgid "#%(trimmed_invoice_count)s trimmed invoice"
 msgid_plural "#%(trimmed_invoice_count)s trimmed invoices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: testapp/templates/i18n_test.jinja:1
+#, python-format
+msgid "Foo %(bar)s"
+msgstr ""
+
+#: testapp/templates/i18n_test.jinja:19
+#, python-format
+msgid "4 There is %(count)s %(name)s object."
+msgid_plural "4 There are %(count)s %(name)s objects."
+msgstr[0] ""
+msgstr[1] ""
+
+#: testapp/templates/i18n_test.jinja:32
+#, python-format
+msgid "#%(invoice_count)s invoice"
+msgid_plural "#%(invoice_count)s invoices"
 msgstr[0] ""
 msgstr[1] ""

--- a/testing/settings.py
+++ b/testing/settings.py
@@ -86,6 +86,9 @@ TEMPLATES = [
             "constants": {
                 "foo": "bar",
             },
+            "policies": {
+                "ext.i18n.trimmed": True,
+            },
             "extensions": DEFAULT_EXTENSIONS + [
                 "django_jinja.builtins.extensions.DjangoExtraFiltersExtension",
             ]

--- a/testing/testapp/templates/i18n_test.jinja
+++ b/testing/testapp/templates/i18n_test.jinja
@@ -10,7 +10,7 @@ Foo {{ bar }}
 <p>{% trans user=user.username %}2 Hello {{ user }}!{% endtrans %}</p>
 
 <p>
-{% trans book_title=book.title, author=author.name %}
+{% trans notrimmed book_title=book.title, author=author.name %}
 3 This is {{ book_title }} by {{ author }}
 {% endtrans %}
 </p>


### PR DESCRIPTION
Fixes #284.

In their 2.9, Jinja2 added a `policies` dict on the base Environment, which controls rendering behaviours.

This change adds the ability to set those policies via django settings, and adds a section about it in the docs.

I tested this out by adding the `ext.i18n.trimmed` setting to the testapp's template options dict, and indeed the i18n view started rendering with everything trimmed.

**Update**: I've now figured out how to get this trimming policy to work with our custom `makemessages` command, by inserting `trimmed` in all the right places, assuming `ext.i18n.trimmed` is enabled.

To test this feature out in your project, you can install this branch thusly:

```
pip install -e git+https://github.com/wizpig64/django-jinja.git@ade847b3e5e4140809e7ea5a46c51ae175af3d31#egg=django_jinja
```