### PR TITLE
Avoid Django 3.2+ deprecation warning about unnecessary default_app_configs

### DIFF
--- a/django_jinja/__init__.py
+++ b/django_jinja/__init__.py
@@ -1,1 +1,4 @@
-default_app_config = 'django_jinja.apps.DjangoJinjaAppConfig'
+from django import VERSION
+
+if VERSION < (3, 2):
+    default_app_config = 'django_jinja.apps.DjangoJinjaAppConfig'


### PR DESCRIPTION
Since Django 3.2, [a single AppConfig is automatically determined](https://docs.djangoproject.com/en/3.2/releases/3.2/#automatic-appconfig-discovery).

When running in [Python Development Mode](https://docs.python.org/3/library/devmode.html), this shows up as a warning.