### PR TITLE
Django 4.1

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -6,6 +6,8 @@ Unreleased
 
 - Drop Django 2.2 support, now require >=3.2.
 - Drop Python 3.6 support, now require >=3.7.
+- Add Django 4.1 support.
+- Add Python 3.11 support.
 
 
 Version 2.10.2

--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- Drop Django 2.2 support, now require >=3.2.
+- Drop Python 3.6 support, now require >=3.7.
+
 
 Version 2.10.2
 --------------

--- a/django_jinja/__init__.py
+++ b/django_jinja/__init__.py
@@ -1,4 +1,0 @@
-from django import VERSION
-
-if VERSION < (3, 2):
-    default_app_config = 'django_jinja.apps.DjangoJinjaAppConfig'

--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -53,8 +53,8 @@ in the "Custom filters, globals, constants and tests" section.
 
 === Requirements
 
-- Python >= 3.6
-- Django >= 2.2
+- Python >= 3.7
+- Django >= 3.2
 - jinja2 >= 3.0
 
 If you are using older versions of Django or Python, you need an older version of django-jinja:
@@ -85,6 +85,10 @@ If you are using older versions of Django or Python, you need an older version o
 |>=2.10.0
 |3.6, 3.7, 3.8, 3.9, 3.10
 |2.2, 3.2, 4.0
+
+|>=2.next
+|3.7, 3.8, 3.9, 3.10
+|3.2, 4.0
 |===
 
 

--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -87,8 +87,8 @@ If you are using older versions of Django or Python, you need an older version o
 |2.2, 3.2, 4.0
 
 |>=2.next
-|3.7, 3.8, 3.9, 3.10
-|3.2, 4.0
+|3.7, 3.8, 3.9, 3.10, 3.11
+|3.2, 4.0, 4.1
 |===
 
 

--- a/setup.py
+++ b/setup.py
@@ -31,10 +31,10 @@ setup(
         "django_jinja.views.generic",
     ],
     include_package_data = True,
-    python_requires = ">=3.6",
+    python_requires = ">=3.7",
     install_requires = [
         "jinja2>=3",
-        "django>=2.2",
+        "django>=3.2",
     ],
     tests_require = [
         "pytz",
@@ -42,7 +42,6 @@ setup(
     classifiers = [
         "Development Status :: 5 - Production/Stable",
         "Framework :: Django",
-        "Framework :: Django :: 2.2",
         "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.0",
         "Intended Audience :: Developers",
@@ -51,7 +50,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         "Framework :: Django",
         "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.0",
+        "Framework :: Django :: 4.1",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
@@ -54,6 +55,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Internet :: WWW/HTTP",
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
-    py{37,38,39,310}-django32
-    py{38,39,310}-django40
+    py{37,38,39,310,311}-django32
+    py{38,39,310,311}-django40
+    py{38,39,310,311}-django41
 
 [gh-actions]
 python =
@@ -9,6 +10,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [testenv]
 changedir=testing
@@ -16,4 +18,5 @@ commands=python runtests.py
 deps=
     django32: Django~=3.2
     django40: Django~=4.0
+    django41: Django~=4.1
     jinja2

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,10 @@
 [tox]
 envlist =
-    py{36,37,38,39}-django22
-    py{36,37,38,39,310}-django32
+    py{37,38,39,310}-django32
     py{38,39,310}-django40
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39
@@ -16,7 +14,6 @@ python =
 changedir=testing
 commands=python runtests.py
 deps=
-    django22: Django~=2.2
     django32: Django~=3.2
     django40: Django~=4.0
     jinja2

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
-    3.11: py311
+    3.11-dev: py311
 
 [testenv]
 changedir=testing


### PR DESCRIPTION
- Drop Django 2.2 support, now require >=3.2.
- Drop Python 3.6 support, now require >=3.7.
- Add Django 4.1 support.
- Add Python 3.11 support (currently pre-release).

This pull has a bunch of metadata changes to accomplish the above, and but for `default_app_config`, no code changes have been made. So the current release should work just fine for users of 4.1 or 3.11. For this reason, I won't be in a hurry to release this as a new version until any necessary PRs come up.
