### PR TITLE
makemessages: support jinja's trim_blocks and lstrip_blocks

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- Add Django 5.0 support.
+- Switch from `setup.py` to `pyproject.toml`-style package definition.
+
+
 Version 2.11.0
 --------------
 

--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -6,6 +6,7 @@ Unreleased
 
 - Add Django 5.0 support.
 - Switch from `setup.py` to `pyproject.toml`-style package definition.
+- The `makemessages` management command emulates Jinja's `trim_blocks` and `lstrip_blocks` settings.
 
 
 Version 2.11.0

--- a/django_jinja/backend.py
+++ b/django_jinja/backend.py
@@ -184,6 +184,8 @@ class Jinja2(BaseEngine):
         options.setdefault("extensions", builtins.DEFAULT_EXTENSIONS)
         options.setdefault("auto_reload", settings.DEBUG)
         options.setdefault("autoescape", True)
+        options.setdefault("trim_blocks", False)
+        options.setdefault("lstrip_blocks", False)
 
         self.env = environment_cls(**options)
 

--- a/django_jinja/management/commands/makemessages.py
+++ b/django_jinja/management/commands/makemessages.py
@@ -32,10 +32,10 @@ from django.template.base import BLOCK_TAG_START, BLOCK_TAG_END
 from django.utils.translation import template as trans_real
 
 
-strip_whitespace_right = re.compile(fr"({BLOCK_TAG_START}-?\s*(trans|pluralize).*?-{BLOCK_TAG_END})\s+", re.U)
-strip_whitespace_left = re.compile(fr"\s+({BLOCK_TAG_START}-\s*(endtrans|pluralize).*?-?{BLOCK_TAG_END})", re.U)
-trim_blocks = re.compile(fr"({BLOCK_TAG_START}-?\s*(trans|pluralize)[^+]*?{BLOCK_TAG_END})\n", re.U)
-lstrip_blocks = re.compile(fr"^[ \t]+({BLOCK_TAG_START}\s*(endtrans|pluralize).*?-?{BLOCK_TAG_END})", re.U | re.M)
+strip_whitespace_right = re.compile(fr"({BLOCK_TAG_START}[-+]?\s*(trans|pluralize).*?-{BLOCK_TAG_END})\s+", re.U)
+strip_whitespace_left = re.compile(fr"\s+({BLOCK_TAG_START}-\s*(endtrans|pluralize).*?[-+]?{BLOCK_TAG_END})", re.U)
+trim_blocks = re.compile(fr"({BLOCK_TAG_START}[-+]?\s*(trans|pluralize)[^+]*?{BLOCK_TAG_END})\n", re.U)
+lstrip_blocks = re.compile(fr"^[ \t]+({BLOCK_TAG_START}\s*(endtrans|pluralize).*?[-+]?{BLOCK_TAG_END})", re.U | re.M)
 
 
 def strip_whitespaces(src, engine):
@@ -51,8 +51,8 @@ def strip_whitespaces(src, engine):
 # this regex looks for {% trans %} blocks that don't have 'trimmed' or 'notrimmed' set.
 # capturing {% endtrans %} ensures this doesn't affect DTL {% trans %} tags.
 trans_block_re = re.compile(
-    fr"({BLOCK_TAG_START}-?\s*trans)(?!\s+(?:no)?trimmed)"
-    fr"(.*?{BLOCK_TAG_END}.*?{BLOCK_TAG_START}-?\s*?endtrans\s*?-?{BLOCK_TAG_END})",
+    fr"({BLOCK_TAG_START}[-+]?\s*trans)(?!\s+(?:no)?trimmed)"
+    fr"(.*?{BLOCK_TAG_END}.*?{BLOCK_TAG_START}[-+]?\s*?endtrans\s*?[-+]?{BLOCK_TAG_END})",
     re.U | re.DOTALL
 )
 
@@ -88,11 +88,11 @@ class Command(makemessages.Command):
         # Extend the regular expressions that are used to detect
         # translation blocks with an "OR jinja-syntax" clause.
         trans_real.endblock_re = re.compile(
-            trans_real.endblock_re.pattern + '|' + r"""^-?\s*endtrans\s*-?$""")
+            trans_real.endblock_re.pattern + '|' + r"""^[-+]?\s*endtrans\s*[-+]?$""")
         trans_real.block_re = re.compile(
-            trans_real.block_re.pattern + '|' + r"""^-?\s*trans(?:\s+(?:no)?trimmed)?(?:\s+(?!'|")(?=.*?=.*?)|\s*-?$)""")
+            trans_real.block_re.pattern + '|' + r"""^[-+]?\s*trans(?:\s+(?:no)?trimmed)?(?:\s+(?!'|")(?=.*?=.*?)|\s*[-+]?$)""")
         trans_real.plural_re = re.compile(
-            trans_real.plural_re.pattern + '|' + r"""^-?\s*pluralize(?:\s+.+|-?$)""")
+            trans_real.plural_re.pattern + '|' + r"""^[-+]?\s*pluralize(?:\s+.+|[-+]?$)""")
         trans_real.constant_re = re.compile(r""".*?_\(((?:".*?(?<!\\)")|(?:'.*?(?<!\\)')).*?\)""")
 
         if options['jinja_engine']:

--- a/django_jinja/management/commands/makemessages.py
+++ b/django_jinja/management/commands/makemessages.py
@@ -34,11 +34,17 @@ from django.utils.translation import template as trans_real
 
 strip_whitespace_right = re.compile(fr"({BLOCK_TAG_START}-?\s*(trans|pluralize).*?-{BLOCK_TAG_END})\s+", re.U)
 strip_whitespace_left = re.compile(fr"\s+({BLOCK_TAG_START}-\s*(endtrans|pluralize).*?-?{BLOCK_TAG_END})", re.U)
+trim_blocks = re.compile(fr"({BLOCK_TAG_START}-?\s*(trans|pluralize)[^+]*?{BLOCK_TAG_END})\n", re.U)
+lstrip_blocks = re.compile(fr"^[ \t]+({BLOCK_TAG_START}\s*(endtrans|pluralize).*?-?{BLOCK_TAG_END})", re.U | re.M)
 
 
-def strip_whitespaces(src):
+def strip_whitespaces(src, engine):
     src = strip_whitespace_left.sub(r'\1', src)
     src = strip_whitespace_right.sub(r'\1', src)
+    if engine.get("OPTIONS", {}).get("trim_blocks"):
+        src = trim_blocks.sub(r'\1', src)
+    if engine.get("OPTIONS", {}).get("lstrip_blocks"):
+        src = lstrip_blocks.sub(r'\1', src)
     return src
 
 
@@ -95,7 +101,7 @@ class Command(makemessages.Command):
             jinja_engine = self._get_default_jinja_template_engine()
 
         def my_templatize(src, origin=None, **kwargs):
-            new_src = strip_whitespaces(src)
+            new_src = strip_whitespaces(src, jinja_engine)
             new_src = apply_i18n_trimmed_policy(new_src, jinja_engine)
             return old_templatize(new_src, origin, **kwargs)
 

--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -88,7 +88,7 @@ If you are using older versions of Django or Python, you need an older version o
 
 |>=2.11.0
 |3.8, 3.9, 3.10, 3.11
-|3.2, 4.0, 4.1, 4.2
+|3.2, 4.0, 4.1, 4.2, 5.0 (dev version only)
 |===
 
 

--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -37,7 +37,7 @@ list of differences with django's built-in backend:
   It works as middleware, intercepts Jinja templates by file path pattern.
 - Django template filters and tags can mostly be used in Jinja2 templates.
 - I18n subsystem adapted for Jinja2 (makemessages now collects messages from
-  Jinja templates, respects the `ext.i18n.trimmed` policy)
+  Jinja templates, respects the `ext.i18n.trimmed` policy, `trim_blocks`, `lstrip_blocks`)
 - jinja2 bytecode cache adapted for using django's cache subsystem.
 - Support for django context processors.
 
@@ -412,6 +412,8 @@ TEMPLATES = [
                 "backend": "django_jinja.cache.BytecodeCache",
                 "enabled": False,
             },
+            "strip_blocks": False,
+            "lstrip_blocks": False,
             "autoescape": True,
             "auto_reload": settings.DEBUG,
             "translation_engine": "django.utils.translation",

--- a/testing/locale/en/LC_MESSAGES/django.noi18ntrim.lstrip.po
+++ b/testing/locale/en/LC_MESSAGES/django.noi18ntrim.lstrip.po
@@ -1,4 +1,4 @@
-#: testapp/templates/i18n_test.html:1
+#: testapp/templates/i18n_test.html:1 testapp/templates/i18n_test.jinja:1
 #, python-format
 msgid ""
 "\n"
@@ -26,7 +26,7 @@ msgid ""
 "3 This is %(book_title)s by %(author)s\n"
 msgstr ""
 
-#: testapp/templates/i18n_test.html:20
+#: testapp/templates/i18n_test.html:20 testapp/templates/i18n_test.jinja:19
 #, python-format
 msgid ""
 "\n"
@@ -41,7 +41,7 @@ msgstr[1] ""
 msgid "5 Hello World!"
 msgstr ""
 
-#: testapp/templates/i18n_test.html:33
+#: testapp/templates/i18n_test.html:33 testapp/templates/i18n_test.jinja:32
 #, python-format
 msgid ""
 "\n"
@@ -59,25 +59,6 @@ msgid_plural "#%(trimmed_invoice_count)s trimmed invoices"
 msgstr[0] ""
 msgstr[1] ""
 
-#: testapp/templates/i18n_test.jinja:1
-#, python-format
-msgid "Foo %(bar)s"
-msgstr ""
-
-#: testapp/templates/i18n_test.jinja:19
-#, python-format
-msgid "4 There is %(count)s %(name)s object."
-msgid_plural "4 There are %(count)s %(name)s objects."
-msgstr[0] ""
-msgstr[1] ""
-
-#: testapp/templates/i18n_test.jinja:32
-#, python-format
-msgid "#%(invoice_count)s invoice"
-msgid_plural "#%(invoice_count)s invoices"
-msgstr[0] ""
-msgstr[1] ""
-
 #: testapp/templates/i18n_test.jinja:48
 #, python-format
 msgid ""
@@ -91,21 +72,31 @@ msgstr[1] ""
 
 #: testapp/templates/i18n_test.jinja:56
 #, python-format
-msgid "#%(trimmed_invoice_count)s dash on my left"
-msgid_plural "#%(trimmed_invoice_count)s dash on my right"
+msgid "#%(trimmed_invoice_count)s dash on my left\n"
+msgid_plural ""
+"\n"
+"  #%(trimmed_invoice_count)s dash on my right"
 msgstr[0] ""
 msgstr[1] ""
 
 #: testapp/templates/i18n_test.jinja:62
 #, python-format
-msgid "#%(trimmed_invoice_count)s plus on my left"
-msgid_plural "#%(trimmed_invoice_count)s plus on my right"
+msgid ""
+"\n"
+"  #%(trimmed_invoice_count)s plus on my left\n"
+msgid_plural ""
+"\n"
+"  #%(trimmed_invoice_count)s plus on my right\n"
 msgstr[0] ""
 msgstr[1] ""
 
 #: testapp/templates/i18n_test.jinja:70
 #, python-format
-msgid "#%(invoice_count)s tabbed for lstrip"
-msgid_plural "#%(invoice_count)s tabbed for lstrip plural"
+msgid ""
+"\n"
+"    #%(invoice_count)s tabbed for lstrip\n"
+msgid_plural ""
+"\n"
+"    #%(invoice_count)s tabbed for lstrip plural\n"
 msgstr[0] ""
 msgstr[1] ""

--- a/testing/locale/en/LC_MESSAGES/django.noi18ntrim.po
+++ b/testing/locale/en/LC_MESSAGES/django.noi18ntrim.po
@@ -1,4 +1,4 @@
-#: testapp/templates/i18n_test.html:1
+#: testapp/templates/i18n_test.html:1 testapp/templates/i18n_test.jinja:1
 #, python-format
 msgid ""
 "\n"
@@ -26,7 +26,7 @@ msgid ""
 "3 This is %(book_title)s by %(author)s\n"
 msgstr ""
 
-#: testapp/templates/i18n_test.html:20
+#: testapp/templates/i18n_test.html:20 testapp/templates/i18n_test.jinja:19
 #, python-format
 msgid ""
 "\n"
@@ -41,7 +41,7 @@ msgstr[1] ""
 msgid "5 Hello World!"
 msgstr ""
 
-#: testapp/templates/i18n_test.html:33
+#: testapp/templates/i18n_test.html:33 testapp/templates/i18n_test.jinja:32
 #, python-format
 msgid ""
 "\n"
@@ -59,25 +59,6 @@ msgid_plural "#%(trimmed_invoice_count)s trimmed invoices"
 msgstr[0] ""
 msgstr[1] ""
 
-#: testapp/templates/i18n_test.jinja:1
-#, python-format
-msgid "Foo %(bar)s"
-msgstr ""
-
-#: testapp/templates/i18n_test.jinja:19
-#, python-format
-msgid "4 There is %(count)s %(name)s object."
-msgid_plural "4 There are %(count)s %(name)s objects."
-msgstr[0] ""
-msgstr[1] ""
-
-#: testapp/templates/i18n_test.jinja:32
-#, python-format
-msgid "#%(invoice_count)s invoice"
-msgid_plural "#%(invoice_count)s invoices"
-msgstr[0] ""
-msgstr[1] ""
-
 #: testapp/templates/i18n_test.jinja:48
 #, python-format
 msgid ""
@@ -91,21 +72,33 @@ msgstr[1] ""
 
 #: testapp/templates/i18n_test.jinja:56
 #, python-format
-msgid "#%(trimmed_invoice_count)s dash on my left"
-msgid_plural "#%(trimmed_invoice_count)s dash on my right"
+msgid "#%(trimmed_invoice_count)s dash on my left\n"
+msgid_plural ""
+"\n"
+"  #%(trimmed_invoice_count)s dash on my right"
 msgstr[0] ""
 msgstr[1] ""
 
 #: testapp/templates/i18n_test.jinja:62
 #, python-format
-msgid "#%(trimmed_invoice_count)s plus on my left"
-msgid_plural "#%(trimmed_invoice_count)s plus on my right"
+msgid ""
+"\n"
+"  #%(trimmed_invoice_count)s plus on my left\n"
+msgid_plural ""
+"\n"
+"  #%(trimmed_invoice_count)s plus on my right\n"
 msgstr[0] ""
 msgstr[1] ""
 
 #: testapp/templates/i18n_test.jinja:70
 #, python-format
-msgid "#%(invoice_count)s tabbed for lstrip"
-msgid_plural "#%(invoice_count)s tabbed for lstrip plural"
+msgid ""
+"\n"
+"    #%(invoice_count)s tabbed for lstrip\n"
+"  "
+msgid_plural ""
+"\n"
+"    #%(invoice_count)s tabbed for lstrip plural\n"
+"  "
 msgstr[0] ""
 msgstr[1] ""

--- a/testing/locale/en/LC_MESSAGES/django.noi18ntrim.trim.lstrip.po
+++ b/testing/locale/en/LC_MESSAGES/django.noi18ntrim.trim.lstrip.po
@@ -1,0 +1,105 @@
+#: testapp/templates/i18n_test.html:1
+#, python-format
+msgid ""
+"\n"
+"Foo %(bar)s\n"
+msgstr ""
+
+#: testapp/templates/i18n_test.html:5 testapp/templates/i18n_test.jinja:5
+msgid "Year"
+msgstr ""
+
+#: testapp/templates/i18n_test.html:7 testapp/templates/i18n_test.jinja:7
+#, python-format
+msgid "1 Hello %(user)s!"
+msgstr ""
+
+#: testapp/templates/i18n_test.html:9 testapp/templates/i18n_test.jinja:9
+#, python-format
+msgid "2 Hello %(user)s!"
+msgstr ""
+
+#: testapp/templates/i18n_test.html:12
+#, python-format
+msgid ""
+"\n"
+"3 This is %(book_title)s by %(author)s\n"
+msgstr ""
+
+#: testapp/templates/i18n_test.html:18
+#, python-format
+msgid ""
+"\n"
+"4 There is %(count)s %(name)s object.\n"
+msgid_plural ""
+"\n"
+"4 There are %(count)s %(name)s objects.\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: testapp/templates/i18n_test.html:25 testapp/templates/i18n_test.jinja:22
+msgid "5 Hello World!"
+msgstr ""
+
+#: testapp/templates/i18n_test.html:31 testapp/templates/i18n_test.jinja:28
+#, python-format
+msgid "  #%(invoice_count)s invoice\n"
+msgid_plural ""
+"\n"
+"  #%(invoice_count)s invoices\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: testapp/templates/i18n_test.html:38 testapp/templates/i18n_test.jinja:34
+#, python-format
+msgid "#%(trimmed_invoice_count)s trimmed invoice"
+msgid_plural "#%(trimmed_invoice_count)s trimmed invoices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: testapp/templates/i18n_test.jinja:1
+#, python-format
+msgid "Foo %(bar)s\n"
+msgstr ""
+
+#: testapp/templates/i18n_test.jinja:12
+#, python-format
+msgid "3 This is %(book_title)s by %(author)s\n"
+msgstr ""
+
+#: testapp/templates/i18n_test.jinja:17
+#, python-format
+msgid "4 There is %(count)s %(name)s object.\n"
+msgid_plural "4 There are %(count)s %(name)s objects.\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: testapp/templates/i18n_test.jinja:40
+#, python-format
+msgid "  #%(trimmed_invoice_count)s notrimmed invoice\n"
+msgid_plural "  #%(trimmed_invoice_count)s notrimmed invoices\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: testapp/templates/i18n_test.jinja:46
+#, python-format
+msgid "#%(trimmed_invoice_count)s dash on my left\n"
+msgid_plural "  #%(trimmed_invoice_count)s dash on my right"
+msgstr[0] ""
+msgstr[1] ""
+
+#: testapp/templates/i18n_test.jinja:51
+#, python-format
+msgid ""
+"\n"
+"  #%(trimmed_invoice_count)s plus on my left\n"
+msgid_plural "  #%(trimmed_invoice_count)s plus on my right\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: testapp/templates/i18n_test.jinja:58
+#, python-format
+msgid "    #%(invoice_count)s tabbed for lstrip\n"
+msgid_plural "    #%(invoice_count)s tabbed for lstrip plural\n"
+msgstr[0] ""
+msgstr[1] ""

--- a/testing/locale/en/LC_MESSAGES/django.noi18ntrim.trim.po
+++ b/testing/locale/en/LC_MESSAGES/django.noi18ntrim.trim.po
@@ -1,0 +1,109 @@
+#: testapp/templates/i18n_test.html:1
+#, python-format
+msgid ""
+"\n"
+"Foo %(bar)s\n"
+msgstr ""
+
+#: testapp/templates/i18n_test.html:5 testapp/templates/i18n_test.jinja:5
+msgid "Year"
+msgstr ""
+
+#: testapp/templates/i18n_test.html:7 testapp/templates/i18n_test.jinja:7
+#, python-format
+msgid "1 Hello %(user)s!"
+msgstr ""
+
+#: testapp/templates/i18n_test.html:9 testapp/templates/i18n_test.jinja:9
+#, python-format
+msgid "2 Hello %(user)s!"
+msgstr ""
+
+#: testapp/templates/i18n_test.html:12
+#, python-format
+msgid ""
+"\n"
+"3 This is %(book_title)s by %(author)s\n"
+msgstr ""
+
+#: testapp/templates/i18n_test.html:18
+#, python-format
+msgid ""
+"\n"
+"4 There is %(count)s %(name)s object.\n"
+msgid_plural ""
+"\n"
+"4 There are %(count)s %(name)s objects.\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: testapp/templates/i18n_test.html:25 testapp/templates/i18n_test.jinja:22
+msgid "5 Hello World!"
+msgstr ""
+
+#: testapp/templates/i18n_test.html:31 testapp/templates/i18n_test.jinja:28
+#, python-format
+msgid "  #%(invoice_count)s invoice\n"
+msgid_plural ""
+"\n"
+"  #%(invoice_count)s invoices\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: testapp/templates/i18n_test.html:38 testapp/templates/i18n_test.jinja:34
+#, python-format
+msgid "#%(trimmed_invoice_count)s trimmed invoice"
+msgid_plural "#%(trimmed_invoice_count)s trimmed invoices"
+msgstr[0] ""
+msgstr[1] ""
+
+#: testapp/templates/i18n_test.jinja:1
+#, python-format
+msgid "Foo %(bar)s\n"
+msgstr ""
+
+#: testapp/templates/i18n_test.jinja:12
+#, python-format
+msgid "3 This is %(book_title)s by %(author)s\n"
+msgstr ""
+
+#: testapp/templates/i18n_test.jinja:17
+#, python-format
+msgid "4 There is %(count)s %(name)s object.\n"
+msgid_plural "4 There are %(count)s %(name)s objects.\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: testapp/templates/i18n_test.jinja:40
+#, python-format
+msgid "  #%(trimmed_invoice_count)s notrimmed invoice\n"
+msgid_plural "  #%(trimmed_invoice_count)s notrimmed invoices\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: testapp/templates/i18n_test.jinja:46
+#, python-format
+msgid "#%(trimmed_invoice_count)s dash on my left\n"
+msgid_plural "  #%(trimmed_invoice_count)s dash on my right"
+msgstr[0] ""
+msgstr[1] ""
+
+#: testapp/templates/i18n_test.jinja:51
+#, python-format
+msgid ""
+"\n"
+"  #%(trimmed_invoice_count)s plus on my left\n"
+msgid_plural "  #%(trimmed_invoice_count)s plus on my right\n"
+msgstr[0] ""
+msgstr[1] ""
+
+#: testapp/templates/i18n_test.jinja:58
+#, python-format
+msgid ""
+"    #%(invoice_count)s tabbed for lstrip\n"
+"  "
+msgid_plural ""
+"    #%(invoice_count)s tabbed for lstrip plural\n"
+"  "
+msgstr[0] ""
+msgstr[1] ""

--- a/testing/settings.py
+++ b/testing/settings.py
@@ -80,6 +80,8 @@ TEMPLATES = [
             "policies": {
                 "ext.i18n.trimmed": True,
             },
+            # "trim_blocks": True,
+            # "lstrip_blocks": True,
             "extensions": DEFAULT_EXTENSIONS + [
                 "django_jinja.builtins.extensions.DjangoExtraFiltersExtension",
             ]

--- a/testing/testapp/templates/i18n_test.jinja
+++ b/testing/testapp/templates/i18n_test.jinja
@@ -43,3 +43,35 @@ Foo {{ bar }}
   #{{ trimmed_invoice_count }} trimmed invoices
 {% endtrans %}
 </p>
+
+</p>
+{% trans notrimmed %}
+  #{{ trimmed_invoice_count }} notrimmed invoice
+{% pluralize %}
+  #{{ trimmed_invoice_count }} notrimmed invoices
+{% endtrans %}
+</p>
+
+</p>
+{% trans -%}
+  #{{ trimmed_invoice_count }} dash on my left
+{% pluralize %}
+  #{{ trimmed_invoice_count }} dash on my right
+{%- endtrans %}
+</p>
+
+</p>
+{% trans +%}
+  #{{ trimmed_invoice_count }} plus on my left
+{% pluralize %}
+  #{{ trimmed_invoice_count }} plus on my right
+{%+ endtrans %}
+</p>
+
+<p>
+  {% trans %}
+    #{{ invoice_count }} tabbed for lstrip
+  {% pluralize %}
+    #{{ invoice_count }} tabbed for lstrip plural
+  {% endtrans %}
+</p>


### PR DESCRIPTION
Hiya,

This change addresses issue #306, enabling support for jinja's [trim_blocks and lstrip_blocks settings](https://jinja.palletsprojects.com/en/3.1.x/api/#jinja2.Environment) when it comes to our makemessages monkeypatch. If those settings are enabled in `TEMPLATES`, their respective transformations are applied to all exported template blocks.

Included are several `.po` files that reflect makemessages's expected output given the combination of each setting, combined with `ext.i18n.trimmed` being turned on or off.
